### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Contact** AnalogIO at *feedback [at] analogio.dk*
 
-We are rewriting our Coffee card app for Cafe Analog to a new cross platform one in Flutter. 
+We are rewriting our Coffee card app for Cafe Analog to a new cross platform one in Flutter.
 With the coffee card app, users are able to buy and use clip card in Cafe Analog @ IT University of Copenhagen.
 
 ## SDKs
@@ -18,23 +18,23 @@ We are building the Flutter app with these SDK versions
 
 ## Contributing
 
-We are invite everyone to report issues and create pull requests to the repository. 
+We are invite everyone to report issues and create pull requests to the repository.
 
 ### Git branch structure
 
 We follow a [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/) inspired setup. The branch structure is as following :
 
-- `develop` **(Main  branch)** The master branch is the main branches. All new branches must check out from here into feature branches and merged back to master. 
-- `production` The production branch reflects the current deployment in production. The production branch is merged with the develop branch every time a new version is released to production.
+- `develop` **(Main  branch)** All new branches must check out from `develop` into feature branches, then merged back to `develop`.
+- `production` Reflects the current deployment in production. The `production` branch is merged with `develop` every time a new version is released to `production`.
 - `feature/{author}/{feature-name}` New features are developed on feature branches following the *feature / author name / feature name branch* structure.
 
-### Merging with the develop branch
+### Merging with the `develop` branch
 
-**A pull request must be created and approved before merging with develop!**
+**A pull request must be created and approved before merging with `develop`!**
 
-We use a **rebase** strategy when merging to develop. When a feature has been finished in development, the feature branch must be rebased with master before merging in order to avoid merge commits.
+We use a **rebase** strategy when merging to `develop`. When a feature has been finished in development, the feature branch must be rebased with `develop` before merging in order to avoid merge commits.
 
-A rebase merge to master can be done in command line like this:
+A rebase merge to `develop` can be done in command line like this:
 
 ```bash
 git fetch


### PR DESCRIPTION
Clean up old references to "master" branch (that was renamed to "develop" recently).
Fix minor grammar mistakes
Reference branch names with backticks
Remove trailing spaces