### PR TITLE
Add `Grid` widget

### DIFF
--- a/lib/utils/responsive.dart
+++ b/lib/utils/responsive.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+/// Returns `true` if the device is <= 325 px wide.
+bool deviceIsSmall(BuildContext context) =>
+    MediaQuery.of(context).size.width <= 325;

--- a/lib/widgets/components/card.dart
+++ b/lib/widgets/components/card.dart
@@ -12,6 +12,7 @@ abstract class CardBase extends StatelessWidget {
   /// If [onTap] is not null, the card will show a
   /// splash effect when tapped.
   const CardBase({
+    Key? key,
     required this.top,
     this.bottom = const SizedBox.shrink(),
     this.gap = 0,
@@ -20,7 +21,7 @@ abstract class CardBase extends StatelessWidget {
     this.dense = false,
     this.disabled = false,
     this.onTap,
-  });
+  }) : super(key: key);
 
   /// Widget to be placed at the top of the card.
   final Widget top;
@@ -51,24 +52,22 @@ abstract class CardBase extends StatelessWidget {
 
   Widget get _cardContent {
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [top, Gap(gap), bottom],
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return UnconstrainedBox(
-      constrainedAxis: Axis.horizontal,
-      child: Tappable(
-        elevation: 1,
-        padding: EdgeInsets.all(dense ? 12 : 24),
-        color: color,
-        borderRadius: BorderRadius.circular(24),
-        borderColor: borderColor,
-        onTap: onTap,
-        child: _cardContent,
-      ),
+    return Tappable(
+      elevation: 1,
+      padding: EdgeInsets.all(dense ? 12 : 24),
+      color: color,
+      borderRadius: BorderRadius.circular(24),
+      borderColor: borderColor,
+      onTap: onTap,
+      child: _cardContent,
     );
   }
 }

--- a/lib/widgets/components/helpers/grid.dart
+++ b/lib/widgets/components/helpers/grid.dart
@@ -13,18 +13,14 @@ extension _GridGapSizes on GridGap {
 class Grid extends StatelessWidget {
   const Grid({
     Key? key,
-    required this.singleColumn,
-    required this.singleColumnSmall,
+    required this.singleColumnOnSmallDevice,
     required this.gap,
     required this.gapSmall,
     required this.children,
   }) : super(key: key);
 
-  /// Whether to show a single column instead of the default two.
-  final bool singleColumn;
-
   /// Whether to show a single column when the display is small.
-  final bool singleColumnSmall;
+  final bool singleColumnOnSmallDevice;
 
   /// Determines the spacing between grid items.
   final GridGap gap;
@@ -41,10 +37,7 @@ class Grid extends StatelessWidget {
   double _verticalGap(bool isSmall) =>
       isSmall ? gapSmall.vertical : gap.vertical;
 
-  int _columns(bool isSmall) {
-    final _singleColumn = isSmall ? singleColumnSmall : singleColumn;
-    return _singleColumn ? 1 : 2;
-  }
+  int _columns(bool isSmall) => isSmall && singleColumnOnSmallDevice ? 1 : 2;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/components/helpers/grid.dart
+++ b/lib/widgets/components/helpers/grid.dart
@@ -1,0 +1,67 @@
+import 'package:coffeecard/utils/responsive.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+
+enum GridGap { normal, tightVertical, tight }
+
+extension _GridGapSizes on GridGap {
+  double get horizontal => this == GridGap.tight ? 8 : 12;
+  double get vertical => this == GridGap.normal ? 12 : 8;
+}
+
+class Grid extends StatelessWidget {
+  const Grid({
+    Key? key,
+    required this.singleColumn,
+    required this.singleColumnSmall,
+    required this.gap,
+    required this.gapSmall,
+    required this.children,
+  }) : super(key: key);
+
+  /// Whether to show a single column instead of the default two.
+  final bool singleColumn;
+
+  /// Whether to show a single column when the display is small.
+  final bool singleColumnSmall;
+
+  /// Determines the spacing between grid items.
+  final GridGap gap;
+
+  /// Determines the spacing between grid items when the display is small.
+  final GridGap gapSmall;
+
+  /// The grid items.
+  final List<Widget> children;
+
+  double _horizontalGap(bool isSmall) =>
+      isSmall ? gapSmall.horizontal : gap.horizontal;
+
+  double _verticalGap(bool isSmall) =>
+      isSmall ? gapSmall.vertical : gap.vertical;
+
+  int _columns(bool isSmall) {
+    final _singleColumn = isSmall ? singleColumnSmall : singleColumn;
+    return _singleColumn ? 1 : 2;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isSmall = deviceIsSmall(context);
+    final horizontalGap = _horizontalGap(isSmall);
+    final verticalGap = _verticalGap(isSmall);
+    final columns = _columns(isSmall);
+
+    return UnconstrainedBox(
+      constrainedAxis: Axis.horizontal,
+      child: LayoutGrid(
+        columnSizes: List.filled(columns, 1.fr),
+        rowSizes: List.filled(children.length, auto),
+        columnGap: horizontalGap,
+        rowGap: verticalGap,
+        children: children,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   gap: 2.0.0
   shimmer: 2.0.0
   animations: 2.0.2
+  flutter_layout_grid: 1.0.3
 
   # Chopper api and rest client
   logger: 1.1.0


### PR DESCRIPTION
closes #121 
based on grid implementation from #122 

Cards have been adjusted slightly to play nicely with parent widgets that allows them to render at their intrinsic size.

All cards, except for `ReceiptCard`, should always sit in either a `Column` or a `Grid`.
`ReceiptCard` should sit in a similar widget that would allow it to display its "natural" size, such as `IntrinsicHeight` or `UnconstrainedBox`.

## Changes
- Add `Grid` widget
- Adjust `CardBase`
- Add `flutter_layout_grid` package
- Add `deviceIsSmall` function in `lib/utils/responsive.dart`