### PR TITLE
Added new UI for disabled shop cards for goods, such as 'Buy one drink'

### DIFF
--- a/lib/widgets/components/shop_card_disabled.dart
+++ b/lib/widgets/components/shop_card_disabled.dart
@@ -1,7 +1,4 @@
-import 'dart:ffi';
-
 import 'package:coffeecard/base/style/colors.dart';
-import 'package:coffeecard/widgets/components/helpers/tappable.dart';
 import 'package:flutter/material.dart';
 
 class ShopCardDisabled extends StatelessWidget {
@@ -17,7 +14,7 @@ class ShopCardDisabled extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Color.fromARGB(255, 128, 124, 124),
+      color: const Color.fromARGB(255, 128, 124, 124),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20),
       ),

--- a/lib/widgets/components/shop_card_disabled.dart
+++ b/lib/widgets/components/shop_card_disabled.dart
@@ -1,0 +1,56 @@
+import 'dart:ffi';
+
+import 'package:coffeecard/base/style/colors.dart';
+import 'package:coffeecard/widgets/components/helpers/tappable.dart';
+import 'package:flutter/material.dart';
+
+class ShopCardDisabled extends StatelessWidget {
+  final String title;
+  final IconData icon;
+
+  const ShopCardDisabled({
+    Key? key,
+    required this.title,
+    required this.icon,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Color.fromARGB(255, 128, 124, 124),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Tooltip(
+        message: 'Coming soon',
+        preferBelow: false,
+        verticalOffset: 0,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                    color: AppColor.white,
+                    fontSize: 20,
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Icon(
+                  icon,
+                  color: AppColor.white,
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/components/shop_section.dart
+++ b/lib/widgets/components/shop_section.dart
@@ -2,7 +2,7 @@ import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/base/style/text_styles.dart';
 import 'package:coffeecard/widgets/components/shop_card.dart';
 import 'package:coffeecard/widgets/components/shop_card_disabled.dart';
-import 'package:coffeecard/widgets/pages/buy_one_drink_page.dart';
+//import 'package:coffeecard/widgets/pages/buy_one_drink_page.dart';
 import 'package:coffeecard/widgets/pages/buy_other_page.dart';
 import 'package:coffeecard/widgets/pages/buy_tickets_page.dart';
 import 'package:coffeecard/widgets/pages/redeem_voucher_page.dart';

--- a/lib/widgets/components/shop_section.dart
+++ b/lib/widgets/components/shop_section.dart
@@ -1,6 +1,7 @@
 import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/base/style/text_styles.dart';
 import 'package:coffeecard/widgets/components/shop_card.dart';
+import 'package:coffeecard/widgets/components/shop_card_disabled.dart';
 import 'package:coffeecard/widgets/pages/buy_one_drink_page.dart';
 import 'package:coffeecard/widgets/pages/buy_other_page.dart';
 import 'package:coffeecard/widgets/pages/buy_tickets_page.dart';
@@ -41,17 +42,18 @@ class ShopSection extends StatelessWidget {
                   );
                 },
               ),
-              ShopCard(
+              const ShopCardDisabled(
+                // in future change this class back to ShopCard when feature is ready
                 title: Strings.buyOneDrink,
                 icon: Icons.coffee,
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const BuyOneDrinkPage(),
-                    ),
-                  );
-                },
+                // onPressed: () {
+                //   Navigator.push(
+                //     context,
+                //     MaterialPageRoute(
+                //       builder: (context) => const BuyOneDrinkPage(),
+                //     ),
+                //   );
+                // },
               ),
               ShopCard(
                 title: Strings.buyOther,


### PR DESCRIPTION
Closes #129 

New class "shop_card_disabled" added, which currently holds tooltip "coming soon" which is activated onLongPress. Likewise, colour is now grey to indicate unavailability. The class can also be used for 'Buy others'... etc. 

Couldn't figure out how to add ripple effect, but I guess this is a part of onPressed function, which indeed is left out in the new class (and not necessary). The ripple effect though is mostly style-points to keep it inline with the other boxes. 

Lastly, centering a tooltip is a bit sketchy - but I believe this will work though. 