### PR TITLE
Hotfix: Downgrade code generator version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -692,7 +692,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.13"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,7 @@ dev_dependencies:
   # Chopper api and rest client
   chopper_generator: 4.0.3
   json_serializable: 6.1.4
-  swagger_dart_code_generator: 2.4.1
+  swagger_dart_code_generator: 2.3.13
 
   # linter
   lint: 1.8.2


### PR DESCRIPTION
The new version of [swagger-dart-code-generator](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator) is broken -- code can't be generated (on Windows, at least)

See issue https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/issues/346

We roll back to the previous version