### PR TITLE
Add continue buttons to register flow pages

### DIFF
--- a/lib/widgets/components/entry/register/register_continue_button.dart
+++ b/lib/widgets/components/entry/register/register_continue_button.dart
@@ -1,7 +1,7 @@
 import 'package:coffeecard/widgets/components/rounded_button.dart';
 import 'package:flutter/material.dart';
 
-class RegisterContinueButton extends StatefulWidget {
+class RegisterContinueButton extends StatelessWidget {
   final Function() onPressed;
   final bool enabled;
 
@@ -12,16 +12,11 @@ class RegisterContinueButton extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _RegisterContinueButtonState createState() => _RegisterContinueButtonState();
-}
-
-class _RegisterContinueButtonState extends State<RegisterContinueButton> {
-  @override
   Widget build(BuildContext context) {
     return RoundedButton(
       text: 'Continue',
-      onPressed: widget.onPressed,
-      disabled: !widget.enabled,
+      onPressed: onPressed,
+      disabled: !enabled,
     );
   }
 }

--- a/lib/widgets/components/entry/register/register_continue_button.dart
+++ b/lib/widgets/components/entry/register/register_continue_button.dart
@@ -1,0 +1,27 @@
+import 'package:coffeecard/widgets/components/rounded_button.dart';
+import 'package:flutter/material.dart';
+
+class RegisterContinueButton extends StatefulWidget {
+  final Function() onPressed;
+  final bool enabled;
+
+  const RegisterContinueButton({
+    required this.onPressed,
+    required this.enabled,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  _RegisterContinueButtonState createState() => _RegisterContinueButtonState();
+}
+
+class _RegisterContinueButtonState extends State<RegisterContinueButton> {
+  @override
+  Widget build(BuildContext context) {
+    return RoundedButton(
+      text: 'Continue',
+      onPressed: widget.onPressed,
+      disabled: !widget.enabled,
+    );
+  }
+}

--- a/lib/widgets/components/entry/register/register_email_body.dart
+++ b/lib/widgets/components/entry/register/register_email_body.dart
@@ -2,18 +2,19 @@ import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/register/register_cubit.dart';
 import 'package:coffeecard/utils/debouncer.dart';
 import 'package:coffeecard/utils/email_utils.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_continue_button.dart';
 import 'package:coffeecard/widgets/components/forms/text_field.dart';
 import 'package:coffeecard/widgets/routers/register_flow.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class RegisterEmailTextField extends StatefulWidget {
-  const RegisterEmailTextField();
+class RegisterEmailBody extends StatefulWidget {
+  const RegisterEmailBody();
   @override
-  State<RegisterEmailTextField> createState() => _RegisterEmailTextFieldState();
+  State<RegisterEmailBody> createState() => _RegisterEmailBodyState();
 }
 
-class _RegisterEmailTextFieldState extends State<RegisterEmailTextField> {
+class _RegisterEmailBodyState extends State<RegisterEmailBody> {
   final _controller = TextEditingController();
   final _debounce = Debouncer(delay: const Duration(milliseconds: 250));
 
@@ -84,18 +85,26 @@ class _RegisterEmailTextFieldState extends State<RegisterEmailTextField> {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: AppTextField(
-        label: Strings.registerEmailLabel,
-        hint: Strings.registerEmailHint,
-        autofocus: true,
-        error: errorMessage,
-        type: TextFieldType.email,
-        loading: _loading,
-        showCheckMark: _validated,
-        readOnly: _readOnly,
-        onChanged: _onChanged,
-        onEditingComplete: () => _submit(context),
-        controller: _controller,
+      child: Column(
+        children: [
+          AppTextField(
+            label: Strings.registerEmailLabel,
+            hint: Strings.registerEmailHint,
+            autofocus: true,
+            error: errorMessage,
+            type: TextFieldType.email,
+            loading: _loading,
+            showCheckMark: _validated,
+            readOnly: _readOnly,
+            onChanged: _onChanged,
+            onEditingComplete: () => _submit(context),
+            controller: _controller,
+          ),
+          RegisterContinueButton(
+            onPressed: () => _submit(context),
+            enabled: _validated,
+          )
+        ],
       ),
     );
   }

--- a/lib/widgets/components/entry/register/register_name_body.dart
+++ b/lib/widgets/components/entry/register/register_name_body.dart
@@ -1,6 +1,7 @@
 import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/register/register_cubit.dart';
 import 'package:coffeecard/widgets/components/dialog.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_continue_button.dart';
 import 'package:coffeecard/widgets/components/forms/text_field.dart';
 import 'package:coffeecard/widgets/components/helpers/unordered_list_builder.dart';
 import 'package:coffeecard/widgets/components/loading_overlay.dart';
@@ -8,18 +9,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
-class RegisterNameTextField extends StatefulWidget {
-  const RegisterNameTextField();
+class RegisterNameBody extends StatefulWidget {
+  const RegisterNameBody();
   @override
-  State<RegisterNameTextField> createState() => _RegisterNameTextFieldState();
+  State<RegisterNameBody> createState() => _RegisterNameBodyState();
 }
 
-class _RegisterNameTextFieldState extends State<RegisterNameTextField> {
+class _RegisterNameBodyState extends State<RegisterNameBody> {
   final _controller = TextEditingController();
   String get name => _controller.text;
 
   bool _showError = false;
   String? _error;
+
+  bool _buttonEnabled() => name.isNotEmpty && _error == null;
 
   Future<void> _validateName(String name) async {
     setState(() => _error = name.isEmpty ? Strings.registerNameEmpty : null);
@@ -125,13 +128,21 @@ class _RegisterNameTextFieldState extends State<RegisterNameTextField> {
 
   @override
   Widget build(BuildContext context) {
-    return AppTextField(
-      label: Strings.registerNameLabel,
-      autofocus: true,
-      error: _showError ? _error : null,
-      onChanged: () => _validateName(_controller.text),
-      onEditingComplete: () => _submit(context),
-      controller: _controller,
+    return Column(
+      children: [
+        AppTextField(
+          label: Strings.registerNameLabel,
+          autofocus: true,
+          error: _showError ? _error : null,
+          onChanged: () => _validateName(_controller.text),
+          onEditingComplete: () => _submit(context),
+          controller: _controller,
+        ),
+        RegisterContinueButton(
+          onPressed: () => _submit(context),
+          enabled: _buttonEnabled(),
+        )
+      ],
     );
   }
 }

--- a/lib/widgets/components/entry/register/register_passcode_body.dart
+++ b/lib/widgets/components/entry/register/register_passcode_body.dart
@@ -1,19 +1,18 @@
 import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/register/register_cubit.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_continue_button.dart';
 import 'package:coffeecard/widgets/components/forms/text_field.dart';
 import 'package:coffeecard/widgets/routers/register_flow.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class RegisterPasscodeTextFields extends StatefulWidget {
-  const RegisterPasscodeTextFields();
+class RegisterPasscodeBody extends StatefulWidget {
+  const RegisterPasscodeBody();
   @override
-  State<RegisterPasscodeTextFields> createState() =>
-      _RegisterPasscodeTextFieldsState();
+  State<RegisterPasscodeBody> createState() => _RegisterPasscodeBodyState();
 }
 
-class _RegisterPasscodeTextFieldsState
-    extends State<RegisterPasscodeTextFields> {
+class _RegisterPasscodeBodyState extends State<RegisterPasscodeBody> {
   final _firstPasscodeController = TextEditingController();
   final _secondPasscodeController = TextEditingController();
   final _secondPasscodeFocusNode = FocusNode();
@@ -31,6 +30,11 @@ class _RegisterPasscodeTextFieldsState
   String? _secondError;
   String? get secondError => _secondError;
   set secondError(String? error) => setState(() => _secondError = error);
+
+  bool _buttonEnabled() =>
+      firstPasscode.isNotEmpty &&
+      secondPasscode.isNotEmpty &&
+      !(firstError != null || secondError != null);
 
   void _focusSecondField() {
     _secondPasscodeFocusNode.requestFocus();
@@ -106,6 +110,10 @@ class _RegisterPasscodeTextFieldsState
           controller: _secondPasscodeController,
           focusNode: _secondPasscodeFocusNode,
         ),
+        RegisterContinueButton(
+          onPressed: () => _submit(context),
+          enabled: _buttonEnabled(),
+        )
       ],
     );
   }

--- a/lib/widgets/components/rounded_button.dart
+++ b/lib/widgets/components/rounded_button.dart
@@ -17,6 +17,11 @@ class RoundedButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TextButton(
+      style: disabled
+          ? TextButton.styleFrom(
+              splashFactory: NoSplash.splashFactory,
+            )
+          : null,
       onPressed: disabled ? () => {} : onPressed,
       child: Container(
         decoration: BoxDecoration(

--- a/lib/widgets/pages/register/register_email_page.dart
+++ b/lib/widgets/pages/register/register_email_page.dart
@@ -1,11 +1,11 @@
 import 'package:coffeecard/base/strings.dart';
-import 'package:coffeecard/widgets/components/entry/register/register_email_text_field.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_email_body.dart';
 import 'package:coffeecard/widgets/pages/register/register_page.dart';
 
 class RegisterEmailPage extends RegisterPage {
   const RegisterEmailPage()
       : super(
           sectionTitle: Strings.registerEmailTitle,
-          body: const RegisterEmailTextField(),
+          body: const RegisterEmailBody(),
         );
 }

--- a/lib/widgets/pages/register/register_name_page.dart
+++ b/lib/widgets/pages/register/register_name_page.dart
@@ -1,11 +1,11 @@
 import 'package:coffeecard/base/strings.dart';
-import 'package:coffeecard/widgets/components/entry/register/register_name_text_field.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_name_body.dart';
 import 'package:coffeecard/widgets/pages/register/register_page.dart';
 
 class RegisterNamePage extends RegisterPage {
   const RegisterNamePage()
       : super(
           sectionTitle: Strings.registerNameTitle,
-          body: const RegisterNameTextField(),
+          body: const RegisterNameBody(),
         );
 }

--- a/lib/widgets/pages/register/register_passcode_page.dart
+++ b/lib/widgets/pages/register/register_passcode_page.dart
@@ -1,11 +1,11 @@
 import 'package:coffeecard/base/strings.dart';
-import 'package:coffeecard/widgets/components/entry/register/register_passcode_text_fields.dart';
+import 'package:coffeecard/widgets/components/entry/register/register_passcode_body.dart';
 import 'package:coffeecard/widgets/pages/register/register_page.dart';
 
 class RegisterPasscodePage extends RegisterPage {
   const RegisterPasscodePage()
       : super(
           sectionTitle: Strings.registerPasscodeTitle,
-          body: const RegisterPasscodeTextFields(),
+          body: const RegisterPasscodeBody(),
         );
 }


### PR DESCRIPTION
* each section of the register flow has a continue button that acts in accordance with already defined behavior regarding errors
* rounded_button now hides splash effect when disabled

closes #93 