### PR TITLE
Receipts displays local time

### DIFF
--- a/lib/widgets/components/receipt/receipt_card.dart
+++ b/lib/widgets/components/receipt/receipt_card.dart
@@ -35,8 +35,14 @@ class ReceiptCard extends CardBase with IgnorePointerCard {
               const Gap(16),
               Text(productName, style: AppTextStyle.ownedTicket),
               const Gap(12),
-              Text(timeSince(time), style: AppTextStyle.textFieldBold),
-              Text(_formatter.format(time), style: AppTextStyle.textField),
+              Text(
+                timeSince(time.toLocal()),
+                style: AppTextStyle.textFieldBold,
+              ),
+              Text(
+                _formatter.format(time.toLocal()),
+                style: AppTextStyle.textField,
+              ),
             ],
           ),
           gap: 120,


### PR DESCRIPTION
closes #183 

The data objects still contain their UTC time, but the local time is displayed. Would it be preferred to save the local time in the objects instead? Thoughts?