### PR TITLE
Entry flow is responsive

### DIFF
--- a/lib/widgets/analog_logo.dart
+++ b/lib/widgets/analog_logo.dart
@@ -1,13 +1,15 @@
+import 'package:coffeecard/utils/responsive.dart';
 import 'package:flutter/material.dart';
 
 class AnalogLogo extends StatelessWidget {
-  final double height;
-  const AnalogLogo() : height = 78;
-  const AnalogLogo.small() : height = 52;
+  const AnalogLogo();
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(height: height, child: Image.asset('assets/logo.png'));
+    return SizedBox(
+      height: deviceIsSmall(context) ? 52 : 78,
+      child: Image.asset('assets/logo.png'),
+    );
   }
 }
 

--- a/lib/widgets/components/entry/login/login_numpad.dart
+++ b/lib/widgets/components/entry/login/login_numpad.dart
@@ -1,8 +1,7 @@
-import 'dart:math';
-
 import 'package:coffeecard/base/style/colors.dart';
 import 'package:coffeecard/base/style/text_styles.dart';
 import 'package:coffeecard/cubits/login/login_cubit.dart';
+import 'package:coffeecard/utils/responsive.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show HapticFeedback;
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,29 +12,18 @@ class Numpad extends StatelessWidget {
   Widget build(BuildContext context) {
     const borderInside = BorderSide(color: AppColor.lightGray, width: 2);
 
-    final double bottomPadding = max(
-      24,
-      MediaQuery.of(context).padding.bottom,
-    );
-    final padding = EdgeInsets.only(
-      top: 16,
-      bottom: bottomPadding,
-      left: 32,
-      right: 32,
-    );
-
     return BlocBuilder<LoginCubit, LoginState>(
       builder: (context, state) {
         return Container(
           color: AppColor.white,
           child: Padding(
-            padding: padding,
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 24),
             child: Table(
               border: const TableBorder(
                 horizontalInside: borderInside,
                 verticalInside: borderInside,
               ),
-              children: [
+              children: const [
                 TableRow(
                   children: [
                     NumpadDigitButton('1'),
@@ -59,13 +47,6 @@ class Numpad extends StatelessWidget {
                 ),
                 TableRow(
                   children: [
-                    // TableCell(
-                    //   verticalAlignment: TableCellVerticalAlignment.fill,
-                    //   child: NumpadButton(
-                    //     icon: Icons.backspace,
-                    //     action: NumpadActionReset(),
-                    //   ),
-                    // ),
                     TableCell(
                       verticalAlignment: TableCellVerticalAlignment.fill,
                       child: NumpadActionButton(
@@ -92,7 +73,7 @@ class Numpad extends StatelessWidget {
   }
 }
 
-abstract class NumpadButton extends StatelessWidget {
+class NumpadButton extends StatelessWidget {
   final void Function(BuildContext) onPressed;
   final Widget child;
 
@@ -113,32 +94,42 @@ abstract class NumpadButton extends StatelessWidget {
   }
 }
 
-class NumpadDigitButton extends NumpadButton {
+class NumpadDigitButton extends StatelessWidget {
+  const NumpadDigitButton(this.digit);
   final String digit;
 
-  NumpadDigitButton(this.digit)
-      : super(
-          onPressed: (BuildContext context) {
-            context.read<LoginCubit>().addPasscodeInput(digit);
-          },
-          child: Text(
-            digit,
-            style: AppTextStyle.numpadDigit,
-          ),
-        );
+  @override
+  Widget build(BuildContext context) {
+    return NumpadButton(
+      onPressed: (BuildContext context) {
+        context.read<LoginCubit>().addPasscodeInput(digit);
+      },
+      child: Text(
+        digit,
+        style: deviceIsSmall(context)
+            ? AppTextStyle.ticketsCount
+            : AppTextStyle.numpadDigit,
+      ),
+    );
+  }
 }
 
-class NumpadActionButton extends NumpadButton {
+class NumpadActionButton extends StatelessWidget {
+  const NumpadActionButton({
+    required this.action,
+    required this.icon,
+  });
+
   final void Function(BuildContext) action;
   final IconData icon;
 
-  NumpadActionButton({
-    required this.action,
-    required this.icon,
-  }) : super(
-          onPressed: action,
-          child: Icon(icon),
-        );
+  @override
+  Widget build(BuildContext context) {
+    return NumpadButton(
+      onPressed: action,
+      child: Icon(icon),
+    );
+  }
 }
 
 abstract class NumpadAction {

--- a/lib/widgets/pages/login/login_page.dart
+++ b/lib/widgets/pages/login/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:coffeecard/cubits/login/login_cubit.dart';
+import 'package:coffeecard/utils/responsive.dart';
 import 'package:coffeecard/widgets/analog_logo.dart';
 import 'package:coffeecard/widgets/components/entry/login/login_input_hint.dart';
 import 'package:coffeecard/widgets/components/entry/login/login_title.dart';
@@ -6,6 +7,7 @@ import 'package:coffeecard/widgets/components/loading_overlay.dart';
 import 'package:coffeecard/widgets/components/scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gap/gap.dart';
 
 abstract class LoginPage extends StatelessWidget {
   final Widget inputWidget;
@@ -38,20 +40,19 @@ abstract class LoginPage extends StatelessWidget {
           resizeToAvoidBottomInset: resizeOnKeyboard,
           body: Column(
             children: [
-              Expanded(
-                child: SafeArea(
-                  minimum: const EdgeInsets.all(16),
+              Flexible(
+                child: SingleChildScrollView(
                   child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
+                      Gap(deviceIsSmall(context) ? 16 : 64),
                       const AnalogLogo(),
-                      Container(height: 16),
+                      const Gap(16),
                       const LoginTitle(),
-                      Container(height: 16),
+                      const Gap(16),
                       inputWidget,
-                      Container(height: 16),
+                      const Gap(16),
                       LoginInputHint(defaultHint: inputHint),
-                      Container(height: 12),
+                      const Gap(12),
                       ...ctaChildren,
                     ],
                   ),

--- a/lib/widgets/pages/register/register_page.dart
+++ b/lib/widgets/pages/register/register_page.dart
@@ -12,15 +12,12 @@ abstract class RegisterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return ListView(
       padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SectionTitle.register(sectionTitle),
-          body,
-        ],
-      ),
+      children: [
+        SectionTitle.register(sectionTitle),
+        body,
+      ],
     );
   }
 }


### PR DESCRIPTION
Resolves #178

No page in login or register flow should overflow.

- Analog logo becomes smaller based on screen width
- Numpad becomes smaller based on screen width
  - Numpad paddings adjusted
- Login pages no longer vertically centered (now matches design spec)
  - Login page padding from top based on screen width
- All login and register pages made scrollable as a last resort

Future:
- Consider removing overscroll or replace it with bouncing (design desicion)