### PR TITLE
Resolve #56 (Left-align appBar title on iOS)

### DIFF
--- a/lib/base/style/theme.dart
+++ b/lib/base/style/theme.dart
@@ -2,6 +2,7 @@ import 'package:coffeecard/base/style/colors.dart';
 import 'package:flutter/material.dart';
 
 final ThemeData analogTheme = ThemeData(
+  appBarTheme: const AppBarTheme(centerTitle: false),
   primarySwatch: AppColor.createMaterialColor(AppColor.primary),
   primaryColor: AppColor.primary,
   brightness: Brightness.light,

--- a/lib/base/style/theme.dart
+++ b/lib/base/style/theme.dart
@@ -2,7 +2,7 @@ import 'package:coffeecard/base/style/colors.dart';
 import 'package:flutter/material.dart';
 
 final ThemeData analogTheme = ThemeData(
-  appBarTheme: const AppBarTheme(centerTitle: false),
+  appBarTheme: const AppBarTheme(centerTitle: false, elevation: 0),
   primarySwatch: AppColor.createMaterialColor(AppColor.primary),
   primaryColor: AppColor.primary,
   brightness: Brightness.light,

--- a/lib/widgets/components/scaffold.dart
+++ b/lib/widgets/components/scaffold.dart
@@ -44,7 +44,6 @@ class AppScaffold extends StatelessWidget {
       backgroundColor: AppColor.primary,
       appBar: AppBar(
         title: title,
-        elevation: 0,
         toolbarHeight: appBarHeight,
       ),
       body: BlocBuilder<EnvironmentCubit, EnvironmentState>(


### PR DESCRIPTION
Fix #56 
Added appBarTheme into `theme.dart`, with centerTile=false, alongside moving the default elevation value from `scaffold.dart` into the appBarTheme as well.