### PR TITLE
Move cubits out of service locator

### DIFF
--- a/lib/cubits/authentication/authentication_cubit.dart
+++ b/lib/cubits/authentication/authentication_cubit.dart
@@ -1,8 +1,5 @@
-import 'package:coffeecard/cubits/receipt/receipt_cubit.dart';
-import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
 import 'package:coffeecard/data/storage/secure_storage.dart';
 import 'package:coffeecard/models/account/authenticated_user.dart';
-import 'package:coffeecard/service_locator.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 

--- a/lib/cubits/authentication/authentication_cubit.dart
+++ b/lib/cubits/authentication/authentication_cubit.dart
@@ -44,9 +44,6 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
 
   Future<void> unauthenticated() async {
     await _storage.clearAuthenticatedUser();
-    //Reset all cubits registered in the service locator. Otherwise their state is persisted to other user logins
-    sl<TicketsCubit>().resetCubit();
-    sl<ReceiptCubit>().resetCubit();
     emit(const AuthenticationState.unauthenticated());
   }
 }

--- a/lib/cubits/receipt/receipt_cubit.dart
+++ b/lib/cubits/receipt/receipt_cubit.dart
@@ -32,10 +32,6 @@ class ReceiptCubit extends Cubit<ReceiptState> {
     }
   }
 
-  void resetCubit() {
-    emit(ReceiptState());
-  }
-
   void filterReceipts(ReceiptFilterCategory filterBy) {
     if (filterBy == state.filterBy) return;
     emit(

--- a/lib/cubits/tickets/tickets_cubit.dart
+++ b/lib/cubits/tickets/tickets_cubit.dart
@@ -13,10 +13,6 @@ class TicketsCubit extends Cubit<TicketsState> {
   TicketsCubit(this._ticketRepository) : super(const TicketsLoading());
 
   Future<void> getTickets() async {
-    // Only fetch tickets from backend if they are not loaded already
-    if (state is TicketsLoaded) {
-      return;
-    }
     emit(const TicketsLoading());
     refreshTickets();
   }
@@ -34,10 +30,6 @@ class TicketsCubit extends Cubit<TicketsState> {
         emit(TicketsError(response.left.errorMessage));
       }
     }
-  }
-
-  void resetCubit() {
-    emit(const TicketsLoading());
   }
 
   Future<void> refreshTickets() async {

--- a/lib/service_locator.dart
+++ b/lib/service_locator.dart
@@ -1,7 +1,5 @@
 import 'package:chopper/chopper.dart';
 import 'package:coffeecard/cubits/authentication/authentication_cubit.dart';
-import 'package:coffeecard/cubits/receipt/receipt_cubit.dart';
-import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
 import 'package:coffeecard/data/api/coffee_card_api_constants.dart';
 import 'package:coffeecard/data/api/interceptors/authentication_interceptor.dart';
 import 'package:coffeecard/data/repositories/shared/account_repository.dart';
@@ -130,14 +128,5 @@ void configureServices() {
   // shiftplanning
   sl.registerFactory<OpeningHoursRepository>(
     () => OpeningHoursRepository(sl<ShiftplanningApi>(), sl<Logger>()),
-  );
-
-  // Tickets, other pages need to be able to send requests to refresh it
-  sl.registerSingleton<TicketsCubit>(
-    TicketsCubit(sl.get<TicketRepository>()),
-  );
-  // Receipts, other pages need to be able to send requests to refresh it
-  sl.registerSingleton<ReceiptCubit>(
-    ReceiptCubit(sl.get<ReceiptRepository>()),
   );
 }

--- a/lib/widgets/components/purchase/purchase_overlay.dart
+++ b/lib/widgets/components/purchase/purchase_overlay.dart
@@ -5,7 +5,6 @@ import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
 import 'package:coffeecard/models/purchase/payment.dart';
 import 'package:coffeecard/models/ticket/product.dart';
 import 'package:coffeecard/payment/payment_handler.dart';
-import 'package:coffeecard/service_locator.dart';
 import 'package:coffeecard/widgets/components/purchase/purchase_process.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -38,9 +37,9 @@ Future<Payment?> showPurchaseOverlay({
                   Navigator.pop<Payment>(context, payment);
 
                   //TODO Consider if these calls should be moved elsewhere, e.g. inside the purchase cubit
-                  final ticketCubit = sl.get<TicketsCubit>();
+                  final ticketCubit = context.read<TicketsCubit>();
                   final updateTicketsRequest = ticketCubit.refreshTickets();
-                  final receiptCubit = sl.get<ReceiptCubit>();
+                  final receiptCubit = context.read<ReceiptCubit>();
                   final updateReceiptsRequest = receiptCubit.fetchReceipts();
 
                   await updateTicketsRequest;

--- a/lib/widgets/components/tickets/swipe_ticket_confirm.dart
+++ b/lib/widgets/components/tickets/swipe_ticket_confirm.dart
@@ -4,11 +4,11 @@ import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/base/style/colors.dart';
 import 'package:coffeecard/base/style/text_styles.dart';
 import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
-import 'package:coffeecard/service_locator.dart';
 import 'package:coffeecard/widgets/components/card.dart';
 import 'package:coffeecard/widgets/components/tickets/bottom_modal_sheet_helper.dart';
 import 'package:coffeecard/widgets/components/tickets/slide_to_act.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 Future<T?> showSwipeTicketConfirm<T>({
   required BuildContext context,
@@ -20,6 +20,7 @@ Future<T?> showSwipeTicketConfirm<T>({
     _HeroDialogRoute(
       builder: (_) {
         return _ModalContent(
+          context: context,
           productName: productName,
           amountOwned: amountOwned,
           productId: productId,
@@ -31,11 +32,13 @@ Future<T?> showSwipeTicketConfirm<T>({
 
 class _ModalContent extends StatefulWidget {
   const _ModalContent({
+    required this.context,
     required this.productName,
     required this.amountOwned,
     required this.productId,
   });
 
+  final BuildContext context;
   final String productName;
   final int amountOwned;
   final int productId;
@@ -127,7 +130,9 @@ class _ModalContentState extends State<_ModalContent>
                       onSubmit: () {
                         // Disable hero animation in the reverse direction
                         setState(() => _heroTag = -1);
-                        sl.get<TicketsCubit>().useTicket(widget.productId);
+                        widget.context
+                            .read<TicketsCubit>()
+                            .useTicket(widget.productId);
                       },
                     ),
                   ),

--- a/lib/widgets/pages/home_page.dart
+++ b/lib/widgets/pages/home_page.dart
@@ -8,6 +8,8 @@ import 'package:coffeecard/cubits/user/user_cubit.dart';
 import 'package:coffeecard/data/repositories/shared/account_repository.dart';
 import 'package:coffeecard/data/repositories/v1/leaderboard_repository.dart';
 import 'package:coffeecard/data/repositories/v1/programme_repository.dart';
+import 'package:coffeecard/data/repositories/v1/receipt_repository.dart';
+import 'package:coffeecard/data/repositories/v1/ticket_repository.dart';
 import 'package:coffeecard/service_locator.dart';
 import 'package:coffeecard/widgets/components/helpers/lazy_indexed_stack.dart';
 import 'package:coffeecard/widgets/pages/receipts/receipts_page.dart';
@@ -38,11 +40,15 @@ class _HomePageState extends State<HomePage> {
             sl.get<ProgrammeRepository>(),
           )..fetchUserDetails(),
         ),
-        BlocProvider.value(
-          value: sl.get<TicketsCubit>()..getTickets(),
+        BlocProvider(
+          create: (_) => TicketsCubit(
+            sl.get<TicketRepository>(),
+          )..getTickets(),
         ),
-        BlocProvider.value(
-          value: sl.get<ReceiptCubit>()..fetchReceipts(),
+        BlocProvider(
+          create: (_) => ReceiptCubit(
+            sl.get<ReceiptRepository>(),
+          )..fetchReceipts(),
         ),
         BlocProvider(
           create: (_) => StatisticsCubit(


### PR DESCRIPTION
Fixes a bug with that redundantly runs the initial cubit method listed in home_page.dart and removes the need to reset cubits on logout