### PR TITLE
Update leaderboard after swiping ticket and after changing user info

### DIFF
--- a/lib/cubits/statistics/statistics_cubit.dart
+++ b/lib/cubits/statistics/statistics_cubit.dart
@@ -11,6 +11,7 @@ class StatisticsCubit extends Cubit<StatisticsState> {
   final LeaderboardRepository _repo;
   static const defaultFilterCategory = StatisticsFilterCategory.month;
 
+  /// Load the leaderboard with the given filter category, or the default.
   Future<void> fetchLeaderboards({
     StatisticsFilterCategory category = defaultFilterCategory,
   }) async {
@@ -24,6 +25,20 @@ class StatisticsCubit extends Cubit<StatisticsState> {
     } else {
       // TODO: handle failure
       emit(StatisticsFailure(errorMessage: either.left.errorMessage));
+    }
+  }
+
+  /// Refresh the leaderboard without changing the filter category.
+  ///
+  /// If the leaderboard is not loaded yet, or an error is present,
+  /// load the leaderboard with the default filter category.
+  Future<void> refreshLeaderboards() async {
+    final state = this.state;
+    if (state is! StatisticsStateWithFilterCategory) {
+      return fetchLeaderboards();
+    }
+    if (state is StatisticsLoaded) {
+      return fetchLeaderboards(category: state.filterBy);
     }
   }
 }

--- a/lib/cubits/statistics/statistics_state.dart
+++ b/lib/cubits/statistics/statistics_state.dart
@@ -6,25 +6,33 @@ abstract class StatisticsState extends Equatable {
   const StatisticsState();
 
   @override
-  List<Object?> get props => throw UnimplementedError;
+  List<Object?> get props => [];
 }
 
 class StatisticsInitial extends StatisticsState {}
 
-class StatisticsLoading extends StatisticsState {
-  const StatisticsLoading({required this.filterBy});
+abstract class StatisticsStateWithFilterCategory extends StatisticsState {
+  const StatisticsStateWithFilterCategory(this.filterBy);
   final StatisticsFilterCategory filterBy;
 
   @override
   List<Object?> get props => [filterBy];
 }
 
-class StatisticsLoaded extends StatisticsState {
+class StatisticsLoading extends StatisticsStateWithFilterCategory {
+  const StatisticsLoading({required StatisticsFilterCategory filterBy})
+      : super(filterBy);
+
+  @override
+  List<Object?> get props => [filterBy];
+}
+
+class StatisticsLoaded extends StatisticsStateWithFilterCategory {
   const StatisticsLoaded({
-    required this.filterBy,
     required this.leaderboard,
-  });
-  final StatisticsFilterCategory filterBy;
+    required StatisticsFilterCategory filterBy,
+  }) : super(filterBy);
+
   final List<LeaderboardUser> leaderboard;
 
   @override

--- a/lib/cubits/user/user_cubit.dart
+++ b/lib/cubits/user/user_cubit.dart
@@ -42,7 +42,11 @@ class UserCubit extends Cubit<UserState> {
     final either = await _accountRepository.updateUser(user);
 
     if (either.isRight) {
-      _enrichUserWithProgrammes(either.right);
+      // Refreshes twice as a work-around for
+      // a backend bug that returns a user object with all ranks set to 0.
+      await _enrichUserWithProgrammes(either.right);
+      // FIXME: Remove fetchUserDetails when backend bug is fixed
+      return fetchUserDetails();
     } else {
       emit(UserError(either.left.errorMessage));
     }

--- a/lib/cubits/user/user_state.dart
+++ b/lib/cubits/user/user_state.dart
@@ -13,16 +13,26 @@ class UserError extends UserState {
 
 class UserLoading extends UserState {}
 
-class UserUpdating extends UserLoaded {
+abstract class UserWithData extends UserState {
+  final User user;
+  final List<ProgrammeDto> programmes;
+
+  UserWithData({required this.user, required this.programmes});
+}
+
+class UserUpdating extends UserWithData {
   UserUpdating({required User user, required List<ProgrammeDto> programmes})
       : super(user: user, programmes: programmes);
 }
 
-class UserLoaded extends UserState {
-  final User user;
-  final List<ProgrammeDto> programmes;
+class UserUpdated extends UserWithData {
+  UserUpdated({required User user, required List<ProgrammeDto> programmes})
+      : super(user: user, programmes: programmes);
+}
 
-  UserLoaded({required this.user, required this.programmes});
+class UserLoaded extends UserWithData {
+  UserLoaded({required User user, required List<ProgrammeDto> programmes})
+      : super(user: user, programmes: programmes);
 
   UserLoaded copyWith({
     User? user,

--- a/lib/widgets/components/tickets/tickets_section.dart
+++ b/lib/widgets/components/tickets/tickets_section.dart
@@ -1,6 +1,5 @@
 import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/environment/environment_cubit.dart';
-import 'package:coffeecard/cubits/statistics/statistics_cubit.dart';
 import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
 import 'package:coffeecard/cubits/user/user_cubit.dart';
 import 'package:coffeecard/errors/match_case_incomplete_exception.dart';

--- a/lib/widgets/components/tickets/tickets_section.dart
+++ b/lib/widgets/components/tickets/tickets_section.dart
@@ -1,5 +1,6 @@
 import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/environment/environment_cubit.dart';
+import 'package:coffeecard/cubits/statistics/statistics_cubit.dart';
 import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
 import 'package:coffeecard/errors/match_case_incomplete_exception.dart';
 import 'package:coffeecard/widgets/components/helpers/shimmer_builder.dart';
@@ -27,6 +28,22 @@ class TicketSection extends StatelessWidget {
               // TODO consider using a nicer loading indicator
               LoadingOverlay.of(context).show();
             } else if (state is TicketUsed) {
+              // Refresh or load leaderboard
+              {
+                final statsCubit = context.read<StatisticsCubit>();
+                final statsState = statsCubit.state;
+                if (statsState is StatisticsStateWithFilterCategory) {
+                  statsCubit.fetchLeaderboards(category: statsState.filterBy);
+                } else {
+                  statsCubit.fetchLeaderboards();
+                }
+              }
+
+              // Refresh or load user info (for updated rank stats)
+              {
+                // FIXME: Implement
+              }
+
               final envState = context.read<EnvironmentCubit>().state;
               LoadingOverlay.of(context).hide();
               ReceiptOverlay.of(context).show(

--- a/lib/widgets/components/tickets/tickets_section.dart
+++ b/lib/widgets/components/tickets/tickets_section.dart
@@ -2,6 +2,7 @@ import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/cubits/environment/environment_cubit.dart';
 import 'package:coffeecard/cubits/statistics/statistics_cubit.dart';
 import 'package:coffeecard/cubits/tickets/tickets_cubit.dart';
+import 'package:coffeecard/cubits/user/user_cubit.dart';
 import 'package:coffeecard/errors/match_case_incomplete_exception.dart';
 import 'package:coffeecard/widgets/components/helpers/shimmer_builder.dart';
 import 'package:coffeecard/widgets/components/loading_overlay.dart';
@@ -28,21 +29,9 @@ class TicketSection extends StatelessWidget {
               // TODO consider using a nicer loading indicator
               LoadingOverlay.of(context).show();
             } else if (state is TicketUsed) {
-              // Refresh or load leaderboard
-              {
-                final statsCubit = context.read<StatisticsCubit>();
-                final statsState = statsCubit.state;
-                if (statsState is StatisticsStateWithFilterCategory) {
-                  statsCubit.fetchLeaderboards(category: statsState.filterBy);
-                } else {
-                  statsCubit.fetchLeaderboards();
-                }
-              }
-
               // Refresh or load user info (for updated rank stats)
-              {
-                // FIXME: Implement
-              }
+              // (also refreshes leaderboard)
+              context.read<UserCubit>().fetchUserDetails();
 
               final envState = context.read<EnvironmentCubit>().state;
               LoadingOverlay.of(context).hide();

--- a/lib/widgets/pages/stats_page.dart
+++ b/lib/widgets/pages/stats_page.dart
@@ -19,22 +19,27 @@ class StatsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Future<void> _refresh() async {
-      context.read<UserCubit>().fetchUserDetails();
-      context.read<StatisticsCubit>().fetchLeaderboards();
+    Future<void> _refresh({required bool loadUserData}) async {
+      await Future.wait([
+        if (loadUserData) context.read<UserCubit>().fetchUserDetails(),
+        context.read<StatisticsCubit>().refreshLeaderboards(),
+      ]);
     }
 
-    return AppScaffold.withTitle(
-      title: Strings.statsPageTitle,
-      body: RefreshIndicator(
-        displacement: 24,
-        onRefresh: _refresh,
-        child: ListView(
-          controller: scrollController,
-          children: const [
-            StatsSection(),
-            LeaderboardSection(),
-          ],
+    return BlocListener<UserCubit, UserState>(
+      listenWhen: (_, current) => current is UserLoaded,
+      listener: (context, state) => _refresh(loadUserData: false),
+      child: AppScaffold.withTitle(
+        title: Strings.statsPageTitle,
+        body: RefreshIndicator(
+          displacement: 24,
+          onRefresh: () => _refresh(loadUserData: true),
+          child: ListView(
+            children: const [
+              StatsSection(),
+              LeaderboardSection(),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fix #249
fix~ #248 (see note)

## Workaround
Currently, after updating user info, the user object returned by the backend gives the incorrect rank info. for the user.
We work around this bug by fetching user info an extra time after the user changes user info.