### PR TITLE
Reset nav bar app flows when tapping nav bar icon

### DIFF
--- a/lib/widgets/components/receipt/receipts_list_view.dart
+++ b/lib/widgets/components/receipt/receipts_list_view.dart
@@ -8,6 +8,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
 class ReceiptsListView extends StatelessWidget {
+  const ReceiptsListView({required this.scrollController});
+  final ScrollController scrollController;
+
   @override
   Widget build(BuildContext context) {
     return Expanded(
@@ -25,6 +28,7 @@ class ReceiptsListView extends StatelessWidget {
                     filterCategory: state.filterBy,
                   )
                 : ListView.builder(
+                    controller: scrollController,
                     itemCount: state.filteredReceipts.length,
                     itemBuilder: (_, index) {
                       final r = state.filteredReceipts[index];

--- a/lib/widgets/pages/receipts/receipts_page.dart
+++ b/lib/widgets/pages/receipts/receipts_page.dart
@@ -6,10 +6,14 @@ import 'package:coffeecard/widgets/components/scaffold.dart';
 import 'package:flutter/material.dart';
 
 class ReceiptsPage extends StatelessWidget {
-  const ReceiptsPage();
+  const ReceiptsPage({required this.scrollController});
 
-  static Route get route =>
-      MaterialPageRoute(builder: (_) => const ReceiptsPage());
+  final ScrollController scrollController;
+
+  static Route routeWith({required ScrollController scrollController}) =>
+      MaterialPageRoute(
+        builder: (_) => ReceiptsPage(scrollController: scrollController),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +25,7 @@ class ReceiptsPage extends StatelessWidget {
             title: 'Show',
             dropdown: ReceiptDropdown(),
           ),
-          ReceiptsListView(),
+          ReceiptsListView(scrollController: scrollController),
         ],
       ),
     );

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -15,10 +15,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
 
 class SettingsPage extends StatelessWidget {
-  const SettingsPage();
+  const SettingsPage({required this.scrollController});
 
-  static Route get route =>
-      MaterialPageRoute(builder: (_) => const SettingsPage());
+  final ScrollController scrollController;
+
+  static Route routeWith({required ScrollController scrollController}) =>
+      MaterialPageRoute(
+        builder: (_) => SettingsPage(scrollController: scrollController),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -33,6 +37,7 @@ class SettingsPage extends StatelessWidget {
             );
           }
           return ListView(
+            controller: scrollController,
             children: [
               const Padding(
                 padding: EdgeInsets.only(left: 16, right: 16, top: 16),

--- a/lib/widgets/pages/stats_page.dart
+++ b/lib/widgets/pages/stats_page.dart
@@ -8,10 +8,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class StatsPage extends StatelessWidget {
-  const StatsPage();
+  const StatsPage({required this.scrollController});
 
-  static Route get route =>
-      MaterialPageRoute(builder: (_) => const StatsPage());
+  final ScrollController scrollController;
+
+  static Route routeWith({required ScrollController scrollController}) =>
+      MaterialPageRoute(
+        builder: (_) => StatsPage(scrollController: scrollController),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +30,7 @@ class StatsPage extends StatelessWidget {
         displacement: 24,
         onRefresh: _refresh,
         child: ListView(
+          controller: scrollController,
           children: const [
             StatsSection(),
             LeaderboardSection(),

--- a/lib/widgets/pages/tickets/tickets_page.dart
+++ b/lib/widgets/pages/tickets/tickets_page.dart
@@ -7,10 +7,14 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
 class TicketsPage extends StatelessWidget {
-  const TicketsPage();
+  const TicketsPage({required this.scrollController});
 
-  static Route get route =>
-      MaterialPageRoute(builder: (_) => const TicketsPage());
+  final ScrollController scrollController;
+
+  static Route routeWith({required ScrollController scrollController}) =>
+      MaterialPageRoute(
+        builder: (_) => TicketsPage(scrollController: scrollController),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -21,6 +25,7 @@ class TicketsPage extends StatelessWidget {
         children: [
           Expanded(
             child: ListView(
+              controller: scrollController,
               shrinkWrap: true,
               padding: const EdgeInsets.all(16.0),
               children: const [

--- a/lib/widgets/routers/app_flow.dart
+++ b/lib/widgets/routers/app_flow.dart
@@ -2,15 +2,22 @@ import 'package:flutter/material.dart';
 
 /// Represents a Navigator for a certain flow of the app.
 class AppFlow extends StatefulWidget {
-  const AppFlow({required this.initialRoute});
+  const AppFlow({required this.initialRoute, this.navigatorKey});
   final Route initialRoute;
+  final GlobalKey<NavigatorState>? navigatorKey;
 
   @override
   State<AppFlow> createState() => _AppFlowState();
 }
 
 class _AppFlowState extends State<AppFlow> {
-  final navigatorKey = GlobalKey<NavigatorState>();
+  late GlobalKey<NavigatorState> navigatorKey;
+
+  @override
+  void initState() {
+    super.initState();
+    navigatorKey = widget.navigatorKey ?? GlobalKey<NavigatorState>();
+  }
 
   Future<bool> _didPopRoute() async {
     return navigatorKey.currentState!.maybePop();


### PR DESCRIPTION
Fix #257

New navigation bar behaviour:

- Pressing the nav bar icon of a flow that is not currently active will bring the user to the page they were on before if any; otherwise default
  - (This was the old behaviour for all cases.)

- Pressing the nav bar icon of the flow that is currently active will bring the user back to the default page and scroll that page to the top.