### PR TITLE
Add variable flexibility of `ListEntry`

### DIFF
--- a/lib/widgets/components/list_entry.dart
+++ b/lib/widgets/components/list_entry.dart
@@ -3,7 +3,14 @@ import 'package:coffeecard/widgets/components/helpers/tappable.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
+/// Represents the left or right side of a [ListEntry] widget
+enum ListEntrySide { left, right }
+
 class ListEntry extends StatelessWidget {
+  /// The (left or right) side of the widget that should be displayed in full.
+  /// The other part will resize based on remaining space.
+  final ListEntrySide sideToExpand;
+
   final Widget leftWidget;
   final Widget rightWidget;
   final void Function()? onTap;
@@ -12,19 +19,31 @@ class ListEntry extends StatelessWidget {
   const ListEntry({
     required this.leftWidget,
     required this.rightWidget,
+    required this.sideToExpand,
     this.onTap,
     this.backgroundColor,
   });
 
+  /// Wraps a left or right widget in a [Flexible]
+  /// widget if it's not the [sideToExpand].
+  Widget wrapSideInFlex({required ListEntrySide side, required Widget child}) {
+    if (side == sideToExpand) return child;
+    return Flexible(child: child);
+  }
+
   Widget get _leftWidget {
-    return Flexible(
-      child: Row(
-        children: [Flexible(child: leftWidget), const Gap(24)],
-      ),
+    return wrapSideInFlex(
+      side: ListEntrySide.left,
+      child: leftWidget,
     );
   }
 
-  Widget get _rightWidget => rightWidget;
+  Widget get _rightWidget {
+    return wrapSideInFlex(
+      side: ListEntrySide.right,
+      child: rightWidget,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +56,7 @@ class ListEntry extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [_leftWidget, _rightWidget],
+          children: [_leftWidget, const Gap(24), _rightWidget],
         ),
       ),
     );

--- a/lib/widgets/components/receipt/receipt_list_entry.dart
+++ b/lib/widgets/components/receipt/receipt_list_entry.dart
@@ -46,6 +46,7 @@ class ReceiptListEntry extends StatelessWidget {
           showShimmer: receipt.transactionType == TransactionType.placeholder,
           builder: (context, colorIfShimmer) {
             return ListEntry(
+              sideToExpand: ListEntrySide.right,
               leftWidget: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/widgets/components/settings_list_entry.dart
+++ b/lib/widgets/components/settings_list_entry.dart
@@ -54,11 +54,9 @@ class SettingListEntry extends StatelessWidget {
       height: 50,
       child: ListEntry(
         onTap: _disabled ? null : onTap,
+        sideToExpand: ListEntrySide.left,
         leftWidget: _leftWidget,
-        rightWidget: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 150),
-          child: _rightWidget,
-        ),
+        rightWidget: _rightWidget,
       ),
     );
   }

--- a/lib/widgets/components/stats/leaderboard_entry.dart
+++ b/lib/widgets/components/stats/leaderboard_entry.dart
@@ -34,6 +34,7 @@ class LeaderboardEntry extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListEntry(
       backgroundColor: highlight ? AppColor.slightlyHighlighted : null,
+      sideToExpand: ListEntrySide.right,
       leftWidget: ShimmerBuilder(
         showShimmer: isPlaceholder,
         builder: (context, colorIfShimmer) {

--- a/lib/widgets/pages/settings/settings_page.dart
+++ b/lib/widgets/pages/settings/settings_page.dart
@@ -63,11 +63,10 @@ class SettingsPage extends StatelessWidget {
                       builder: (context, colorIfShimmer) {
                         return Container(
                           color: colorIfShimmer,
-                          child: Text(
-                            (state is UserLoaded)
+                          child: SettingDescription(
+                            text: (state is UserLoaded)
                                 ? state.user.email
                                 : 'Loading...',
-                            style: AppTextStyle.settingValue,
                           ),
                         );
                       },
@@ -79,14 +78,10 @@ class SettingsPage extends StatelessWidget {
                         ChangeEmailPage.routeWith(currentEmail: st.user.email),
                       ),
                     ),
-                    // },
                   ),
                   SettingListEntry(
                     name: Strings.passcode,
-                    valueWidget: Text(
-                      Strings.change,
-                      style: AppTextStyle.settingValue,
-                    ),
+                    valueWidget: const SettingDescription(text: Strings.change),
                     onTap: _ifLoaded(
                       state,
                       (_) => Navigator.push(


### PR DESCRIPTION
Fix #280 

Fully fixes any `ListEntry` jank once and for all (hopefully).

# Motivation
Before, all list entries had the left side widget wrapped in a `Flexible` widget.
This caused a problem with SettingsListEntry, because here, the "variable"-sized widget (e.g. user email text) was on the right side.
The previous solution for that problem was to place the right side widget in a fixed size constrained box, but that fix still doesn't play well with variable length emails.
The proposed solution introduces `sideToExpand` inside of `ListEntry`. It tells the ListEntry which side should be displayed
in full, and which side should be wrapped in a `Flexible` widget (which allows that side to reduce in size based on remaining space).

## Misc
Used correct `SettingDescription` widget for the right side of each `SettingListEntry` that had text on their right side.