### PR TITLE
feat: save encoded passcode in secure storage

### DIFF
--- a/lib/cubits/authentication/authentication_cubit.dart
+++ b/lib/cubits/authentication/authentication_cubit.dart
@@ -24,12 +24,12 @@ class AuthenticationCubit extends Cubit<AuthenticationState> {
 
   Future<void> authenticated(
     String email,
-    String passcode,
+    String encodedPasscode,
     String token,
   ) async {
     await _storage.saveAuthenticatedUser(
       email,
-      passcode,
+      encodedPasscode,
       token,
     );
     emit(

--- a/lib/cubits/login/login_cubit.dart
+++ b/lib/cubits/login/login_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:coffeecard/cubits/authentication/authentication_cubit.dart';
 import 'package:coffeecard/data/repositories/shared/account_repository.dart';
+import 'package:coffeecard/utils/encode_passcode.dart';
 import 'package:coffeecard/utils/http_utils.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -49,15 +50,15 @@ class LoginCubit extends Cubit<LoginState> {
 
     emit(LoginLoading());
 
-    final passcode = _state.passcode;
-    final either = await accountRepository.login(email, passcode);
+    final encodedPasscode = encodePasscode(_state.passcode);
+    final either = await accountRepository.login(email, encodedPasscode);
 
     if (either.isRight) {
       final authenticatedUser = either.right;
 
       authenticationCubit.authenticated(
         authenticatedUser.email,
-        passcode,
+        encodedPasscode,
         authenticatedUser.token,
       );
     } else {

--- a/lib/cubits/register/register_cubit.dart
+++ b/lib/cubits/register/register_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:coffeecard/data/repositories/shared/account_repository.dart';
+import 'package:coffeecard/utils/encode_passcode.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -14,8 +15,11 @@ class RegisterCubit extends Cubit<RegisterState> {
   void setName(String name) => emit(state.copyWith(name: name));
 
   Future<void> register() async {
-    final either =
-        await repository.register(state.name!, state.email!, state.passcode!);
+    final either = await repository.register(
+      state.name!,
+      state.email!,
+      encodePasscode(state.passcode!),
+    );
 
     // TODO: Handle error by emitting new state instead of throwing?
     if (either.isLeft) {

--- a/lib/cubits/user/user_cubit.dart
+++ b/lib/cubits/user/user_cubit.dart
@@ -4,6 +4,7 @@ import 'package:coffeecard/data/repositories/v1/programme_repository.dart';
 import 'package:coffeecard/generated/api/coffeecard_api.swagger.dart';
 import 'package:coffeecard/models/account/update_user.dart';
 import 'package:coffeecard/models/account/user.dart';
+import 'package:coffeecard/utils/encode_passcode.dart';
 import 'package:equatable/equatable.dart';
 
 part 'user_state.dart';
@@ -98,7 +99,7 @@ class UserCubit extends Cubit<UserState> {
   }
 
   Future<void> setUserPasscode(String passcode) async {
-    _updateUser(UpdateUser(password: passcode));
+    _updateUser(UpdateUser(encodedPasscode: encodePasscode(passcode)));
   }
 
   Future<void> setUserProgramme(int programmeId) async {

--- a/lib/data/storage/secure_storage.dart
+++ b/lib/data/storage/secure_storage.dart
@@ -5,7 +5,7 @@ import 'package:logger/logger.dart';
 class SecureStorage {
   static const _emailKey = 'email';
   static const _tokenKey = 'authentication_token';
-  static const _passcodeKey = 'password';
+  static const _encodedPasscodeKey = 'encoded_passcode';
 
   final FlutterSecureStorage _storage;
   final Logger _logger;
@@ -16,13 +16,15 @@ class SecureStorage {
 
   Future<void> saveAuthenticatedUser(
     String email,
-    String passcode,
+    String encodedPasscode,
     String token,
   ) async {
     await _storage.write(key: _emailKey, value: email);
-    await _storage.write(key: _passcodeKey, value: passcode);
+    await _storage.write(key: _encodedPasscodeKey, value: encodedPasscode);
     await _storage.write(key: _tokenKey, value: token);
-    _logger.d('Email ($email), passcode and token added to Secure Storage');
+    _logger.d(
+      'Email ($email), encoded passcode and token added to Secure Storage',
+    );
   }
 
   Future<AuthenticatedUser?> getAuthenticatedUser() async {
@@ -36,9 +38,9 @@ class SecureStorage {
   Future<void> clearAuthenticatedUser() async {
     if (await getAuthenticatedUser() == null) return;
     await _storage.delete(key: _emailKey);
-    await _storage.delete(key: _passcodeKey);
+    await _storage.delete(key: _encodedPasscodeKey);
     await _storage.delete(key: _tokenKey);
-    _logger.d('Email, passcode and token removed from Secure Storage');
+    _logger.d('Email, encoded passcode and token removed from Secure Storage');
   }
 
   Future<void> updateToken(String token) async {
@@ -50,8 +52,8 @@ class SecureStorage {
     return _storage.read(key: _emailKey);
   }
 
-  Future<String?> readPasscode() async {
-    return _storage.read(key: _passcodeKey);
+  Future<String?> readEncodedPasscode() async {
+    return _storage.read(key: _encodedPasscodeKey);
   }
 
   Future<String?> readToken() async {

--- a/lib/models/account/update_user.dart
+++ b/lib/models/account/update_user.dart
@@ -3,14 +3,14 @@ import 'package:equatable/equatable.dart';
 class UpdateUser extends Equatable {
   final String? name;
   final String? email;
-  final String? password;
+  final String? encodedPasscode;
   final bool? privacyActivated;
   final int? programmeId;
 
   const UpdateUser({
     this.name,
     this.email,
-    this.password,
+    this.encodedPasscode,
     this.privacyActivated,
     this.programmeId,
   });
@@ -20,7 +20,7 @@ class UpdateUser extends Equatable {
     return [
       name,
       email,
-      password,
+      encodedPasscode,
       privacyActivated,
       programmeId,
     ];

--- a/lib/utils/encode_passcode.dart
+++ b/lib/utils/encode_passcode.dart
@@ -1,0 +1,9 @@
+import 'dart:convert' show base64Encode, utf8;
+
+import 'package:crypto/crypto.dart' show sha256;
+
+String encodePasscode(String passcode) {
+  final bytes = utf8.encode(passcode);
+  final passcodeHash = sha256.convert(bytes);
+  return base64Encode(passcodeHash.bytes);
+}

--- a/lib/utils/reactivation_authenticator.dart
+++ b/lib/utils/reactivation_authenticator.dart
@@ -74,16 +74,16 @@ class ReactivationAuthenticator extends Authenticator {
     Response response,
   ) async {
     final email = await secureStorage.readEmail();
-    final passcode = await secureStorage.readPasscode();
+    final encodedPasscode = await secureStorage.readEncodedPasscode();
 
-    if (email != null && passcode != null) {
+    if (email != null && encodedPasscode != null) {
       final accountRepository = serviceLocator.get<AccountRepository>();
 
       mutex.lock();
 
       // this call may return 401 which triggers a recursive call, use a guard
       try {
-        final either = await accountRepository.login(email, passcode);
+        final either = await accountRepository.login(email, encodedPasscode);
 
         if (either.isRight) {
           // refresh succeeded, update the token in secure storage

--- a/lib/utils/reactivation_authenticator.dart
+++ b/lib/utils/reactivation_authenticator.dart
@@ -83,10 +83,7 @@ class ReactivationAuthenticator extends Authenticator {
 
       // this call may return 401 which triggers a recursive call, use a guard
       try {
-        final either = await accountRepository.login(
-          email,
-          passcode,
-        );
+        final either = await accountRepository.login(email, passcode);
 
         if (either.isRight) {
           // refresh succeeded, update the token in secure storage


### PR DESCRIPTION
Move encoding responsibility out of account_repository;
Now all its methods expects already encoded passcodes.

Variable and method names for passcodes appropriately named `encodedPasscode` if they expect to be encoded.

Moved encode function to `utils/encode_passcode.dart`

---
Addresses

"TODO: Should probably have another return type in order to support
the intended registration flow?"
in `lib\data\repositories\shared\account_repository.dart`