### PR TITLE
Add license page

### DIFF
--- a/lib/widgets/pages/settings/credits_page.dart
+++ b/lib/widgets/pages/settings/credits_page.dart
@@ -93,9 +93,17 @@ class CreditsPage extends StatelessWidget {
                 ),
               ],
             ),
-            const SettingsGroup(
+            SettingsGroup(
               title: Strings.licenses,
-              listItems: [SettingListEntry(name: Strings.viewLicenses)],
+              listItems: [
+                SettingListEntry(
+                  name: Strings.viewLicenses,
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const LicensePage()),
+                  ),
+                ),
+              ],
             ),
             const Gap(36),
           ],


### PR DESCRIPTION
Built in page by Flutter to show all package licenses, including our own (under package coffeecard)