### PR TITLE
Rolled back swagger_dart_code_generator to 2.6.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'com.google.firebase.crashlytics'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/lib/payment/mobilepay_service.dart
+++ b/lib/payment/mobilepay_service.dart
@@ -32,9 +32,9 @@ class MobilePayService implements PaymentHandler {
       return Right(
         Payment(
           id: purchaseResponse.id,
-          paymentId: paymentDetails.paymentId,
+          paymentId: paymentDetails.paymentId!,
           status: PaymentStatus.awaitingPayment,
-          deeplink: paymentDetails.mobilePayAppRedirectUri,
+          deeplink: paymentDetails.mobilePayAppRedirectUri!,
           purchaseTime: purchaseResponse.dateCreated,
           price: purchaseResponse.totalAmount,
           productId: purchaseResponse.productId,
@@ -87,7 +87,7 @@ class MobilePayService implements PaymentHandler {
     return Left(either.left);
   }
 
-  PaymentStatus _mapPaymentStateToStatus(String state) {
+  PaymentStatus _mapPaymentStateToStatus(String? state) {
     PaymentStatus status;
     switch (state) {
       case 'Initiated':

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -972,7 +972,7 @@ packages:
       name: swagger_dart_code_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.8"
+    version: "2.6.0"
   synchronized:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dev_dependencies:
   # Chopper api and rest client
   chopper_generator: 4.0.6
   json_serializable: 6.3.1
-  swagger_dart_code_generator: 2.7.8
+  swagger_dart_code_generator: 2.6.0
 
   # linter
   lint: 1.10.0


### PR DESCRIPTION
Fix #350 
Rolled back swagger_dart_code_generator to 2.6.0

Also bumped the compile sdk for android to version 33 since that is a requirement of the latest secure storage flutter package that we are also using