### PR TITLE
Placeholder for statistics page when user is unranked

### DIFF
--- a/lib/widgets/components/stats/stat_card.dart
+++ b/lib/widgets/components/stats/stat_card.dart
@@ -10,12 +10,11 @@ class StatisticsCard extends StatelessWidget {
   final int rank;
   final bool loading;
 
-  const StatisticsCard({required this.title, required this.rank})
-      : loading = false;
-
-  const StatisticsCard.loading({required this.title})
-      : rank = 0,
-        loading = true;
+  const StatisticsCard({
+    required this.title,
+    required this.rank,
+    required this.loading,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -42,7 +41,7 @@ class StatisticsCard extends StatelessWidget {
                   children: [
                     if (rank != 0)
                       TextSpan(
-                        text: formatLeaderboardPostfix(rank ?? 0),
+                        text: formatLeaderboardPostfix(rank),
                         style: AppTextStyle.leaderboardScore,
                       ),
                   ],

--- a/lib/widgets/components/stats/stat_card.dart
+++ b/lib/widgets/components/stats/stat_card.dart
@@ -31,7 +31,7 @@ class StatisticsCard extends StatelessWidget {
               color: colorIfShimmer,
               child: Text.rich(
                 TextSpan(
-                  text: '${rank ?? 0}',
+                  text: '${rank == 0 ? '-' : rank}',
                   style: AppTextStyle.ticketsCount,
                   children: [
                     TextSpan(
@@ -52,6 +52,7 @@ class StatisticsCard extends StatelessWidget {
 String formatLeaderboardPostfix(int rank) {
   const def = 'th';
 
+  if (rank == 0) return '';
   if (rank > 10 && rank < 20) return def;
 
   switch (rank % 10) {

--- a/lib/widgets/components/stats/stat_card.dart
+++ b/lib/widgets/components/stats/stat_card.dart
@@ -7,9 +7,15 @@ import 'package:flutter/widgets.dart';
 
 class StatisticsCard extends StatelessWidget {
   final String title;
-  final int? rank;
+  final int rank;
+  final bool loading;
 
-  const StatisticsCard({required this.title, this.rank});
+  const StatisticsCard({required this.title, required this.rank})
+      : loading = false;
+
+  const StatisticsCard.loading({required this.title})
+      : rank = 0,
+        loading = true;
 
   @override
   Widget build(BuildContext context) {
@@ -25,19 +31,20 @@ class StatisticsCard extends StatelessWidget {
       ),
       bottom: CardBottomRow(
         right: ShimmerBuilder(
-          showShimmer: rank == null,
+          showShimmer: loading,
           builder: (context, colorIfShimmer) {
             return ColoredBox(
               color: colorIfShimmer,
               child: Text.rich(
                 TextSpan(
-                  text: '${rank == 0 ? '-' : rank}',
+                  text: '${rank == 0 ? 'N/A' : rank}',
                   style: AppTextStyle.ticketsCount,
                   children: [
-                    TextSpan(
-                      text: formatLeaderboardPostfix(rank ?? 0),
-                      style: AppTextStyle.leaderboardScore,
-                    ),
+                    if (rank != 0)
+                      TextSpan(
+                        text: formatLeaderboardPostfix(rank ?? 0),
+                        style: AppTextStyle.leaderboardScore,
+                      ),
                   ],
                 ),
               ),
@@ -52,7 +59,6 @@ class StatisticsCard extends StatelessWidget {
 String formatLeaderboardPostfix(int rank) {
   const def = 'th';
 
-  if (rank == 0) return '';
   if (rank > 10 && rank < 20) return def;
 
   switch (rank % 10) {

--- a/lib/widgets/components/stats/stats_section.dart
+++ b/lib/widgets/components/stats/stats_section.dart
@@ -26,6 +26,8 @@ class _YourStatsGrid extends StatelessWidget {
 
   final User? user;
 
+  bool get isUserLoading => user == null;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -42,15 +44,18 @@ class _YourStatsGrid extends StatelessWidget {
             children: [
               StatisticsCard(
                 title: Strings.statCardMonth,
-                rank: user?.rankMonth,
+                rank: user?.rankMonth ?? 0,
+                loading: isUserLoading,
               ),
               StatisticsCard(
                 title: Strings.statCardSemester,
-                rank: user?.rankSemester,
+                rank: user?.rankSemester ?? 0,
+                loading: isUserLoading,
               ),
               StatisticsCard(
                 title: Strings.statCardTotal,
-                rank: user?.rankTotal,
+                rank: user?.rankTotal ?? 0,
+                loading: isUserLoading,
               ),
             ],
           ),


### PR DESCRIPTION
closes #357 

When the user has ro rank, instead of displaying "0th" on the statistics page, a dash '-' will now be displayed instead.