### PR TITLE
Fix "In the future" when diff is very small

### DIFF
--- a/lib/utils/time_since.dart
+++ b/lib/utils/time_since.dart
@@ -2,12 +2,11 @@ import 'package:coffeecard/base/strings.dart';
 
 String timeSince(DateTime time) {
   final currentTime = DateTime.now();
+  final diff = currentTime.difference(time);
 
-  if (time.isAfter(currentTime)) {
+  if (time.isAfter(currentTime) && diff.inMinutes < -1) {
     return Strings.inTheFuture;
   }
-
-  final diff = currentTime.difference(time);
 
   if (diff.inMinutes < 2) return Strings.justNow;
   if (diff.inHours < 1) return '${diff.inMinutes} ${Strings.minutesAgo}';

--- a/test/utils/time_since_test.dart
+++ b/test/utils/time_since_test.dart
@@ -44,10 +44,19 @@ void main() {
   });
 
   group('time since tests', () {
-    test('time since given date in the future returns in the future', () {
+    test(
+        'time since given date five minutes in the future returns in the future',
+        () {
+      expect(
+        timeSince(DateTime.now().add(const Duration(minutes: 5))),
+        Strings.inTheFuture,
+      );
+    });
+
+    test('time since given date one minute in the future returns just now', () {
       expect(
         timeSince(DateTime.now().add(const Duration(minutes: 1))),
-        Strings.inTheFuture,
+        Strings.justNow,
       );
     });
 


### PR DESCRIPTION
When time is less than 2 minutes ahead of currentTime, do not display "in the future".

Currently, swipe receipt can display "in the future" because of time differences of a few milliseconds.