### PR TITLE
misc: add `make clean` command

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,3 +13,5 @@ analyze:
 	flutter analyze
 cov:
 	flutter test --coverage && lcov --remove coverage/lcov.info '*/base/*' '*/service_locator.dart' 'lib/generated/*' -o coverage/lcov.info && genhtml coverage/lcov.info -o coverage/html
+clean:
+	flutter clean && flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
Useful when font doesn't show properly in emulator/simulator, or when an unexpected build error occurs locally