### PR TITLE
Fix for OpeningHoursIndicator, so it now behaves as expected on errors

### DIFF
--- a/lib/widgets/components/tickets/opening_hours_indicator.dart
+++ b/lib/widgets/components/tickets/opening_hours_indicator.dart
@@ -15,7 +15,10 @@ class OpeningHoursIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<OpeningHoursCubit, OpeningHoursState>(
       builder: (context, state) {
-        final isOpen = state is! OpeningHoursLoaded || state.isOpen;
+        var isOpen = false;
+        if (state is OpeningHoursLoaded) {
+          isOpen = state.isOpen;
+        }
         final openOrClosed = isOpen ? Strings.open : Strings.closed;
         final color = isOpen ? AppColor.success : AppColor.errorOnBright;
         final textStyle =


### PR DESCRIPTION
With the old code, if the state was an error, the opening status would default to open.