### PR TITLE
ServerFailure returns an unknown error occured

### DIFF
--- a/lib/base/strings.dart
+++ b/lib/base/strings.dart
@@ -360,5 +360,5 @@ abstract class Strings {
   static const String noInternet =
       "Can't connect to Analog. Are you connected to the internet?";
   static const String retry = 'Retry';
-  static const String unknownErrorOccured = 'an unknown error occured';
+  static const String unknownErrorOccured = 'An unknown error occured';
 }

--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -33,7 +33,7 @@ class ServerFailure extends NetworkFailure {
 
       return ServerFailure(message);
     } on Exception {
-      return ServerFailure(response.bodyString);
+      return const ServerFailure(Strings.unknownErrorOccured);
     }
   }
 }

--- a/test/core/network/network_request_executor_test.dart
+++ b/test/core/network/network_request_executor_test.dart
@@ -1,4 +1,5 @@
 import 'package:chopper/chopper.dart' as chopper;
+import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/core/errors/failures.dart';
 import 'package:coffeecard/core/network/network_request_executor.dart';
 import 'package:coffeecard/utils/firebase_analytics_event_logging.dart';
@@ -43,7 +44,7 @@ void main() {
     final actual = await executor(() async => tResponse);
 
     // assert
-    expect(actual, const Left(ServerFailure('')));
+    expect(actual, const Left(ServerFailure(Strings.unknownErrorOccured)));
   });
 
   test('should return response body if api call succeeds', () async {


### PR DESCRIPTION
Closes #447 
Closes #450
ServerFailure returns an unknown error occured, if unable to decode response as json