### PR TITLE
fix(tickets): Fix multiple `CoffeeCard`s sharing the same product id

### DIFF
--- a/lib/features/ticket/data/datasources/ticket_remote_data_source.dart
+++ b/lib/features/ticket/data/datasources/ticket_remote_data_source.dart
@@ -26,14 +26,17 @@ class TicketRemoteDataSource {
       () => apiV2.apiV2TicketsGet(includeUsed: false),
     ).bindFuture(
       (result) => result
-          .groupListsBy((t) => t.productName)
+          .groupListsBy((t) => (t.productName, t.productId))
           .entries
           .map(
-            (t) => TicketCountModel(
-              count: t.value.length,
-              productName: t.key,
-              productId: t.value.first.productId,
-            ),
+            (entry) {
+              final MapEntry(key: (name, id), value: tickets) = entry;
+              return TicketCountModel(
+                count: tickets.length,
+                productName: name,
+                productId: id,
+              );
+            },
           )
           .sortedBy<num>((t) => t.productId)
           .toList(),

--- a/lib/features/ticket/data/datasources/ticket_remote_data_source.dart
+++ b/lib/features/ticket/data/datasources/ticket_remote_data_source.dart
@@ -26,14 +26,17 @@ class TicketRemoteDataSource {
       () => apiV2.apiV2TicketsGet(includeUsed: false),
     ).bindFuture(
       (result) => result
-          .groupListsBy((t) => (t.productName, t.productId))
+          .groupListsBy((t) => t.productId)
           .entries
           .map(
             (entry) {
-              final MapEntry(key: (name, id), value: tickets) = entry;
+              final MapEntry(key: id, value: tickets) = entry;
+              // Join ticket names if they share the same product id
+              final ticketName =
+                  tickets.map((t) => t.productName).toSet().join('/');
               return TicketCountModel(
                 count: tickets.length,
-                productName: name,
+                productName: ticketName,
                 productId: id,
               );
             },

--- a/lib/features/ticket/presentation/widgets/swipe_ticket_confirm.dart
+++ b/lib/features/ticket/presentation/widgets/swipe_ticket_confirm.dart
@@ -53,7 +53,7 @@ class _ModalContentState extends State<_ModalContent>
   late AnimationController _controller;
   late Animation<double> _animation;
 
-  late int _heroTag;
+  late (String, int)? _heroTag;
 
   @override
   void initState() {
@@ -68,7 +68,7 @@ class _ModalContentState extends State<_ModalContent>
       ),
     );
 
-    _heroTag = widget.productId;
+    _heroTag = (widget.productName, widget.productId);
     super.initState();
   }
 
@@ -101,7 +101,7 @@ class _ModalContentState extends State<_ModalContent>
               ],
             ),
             Hero(
-              tag: _heroTag,
+              tag: _heroTag ?? -1,
               // SingleChildScrollView to avoid the temporary overflow
               // error during the hero animation.
               child: SingleChildScrollView(
@@ -130,7 +130,7 @@ class _ModalContentState extends State<_ModalContent>
                       outerColor: AppColor.primary,
                       onSubmit: () async {
                         // Disable hero animation in the reverse direction
-                        setState(() => _heroTag = -1);
+                        setState(() => _heroTag = null);
                         final ticketCubit = widget.context.read<TicketsCubit>();
                         final receiptCubit =
                             widget.context.read<ReceiptCubit>();

--- a/lib/features/ticket/presentation/widgets/tickets_section.dart
+++ b/lib/features/ticket/presentation/widgets/tickets_section.dart
@@ -93,7 +93,7 @@ class TicketSection extends StatelessWidget {
                       (p) => Padding(
                         padding: const EdgeInsets.only(bottom: 12.0),
                         child: Hero(
-                          tag: p.productId,
+                          tag: (p.productName, p.productId),
                           child: CoffeeCard(
                             title: p.productName,
                             amountOwned: p.count,

--- a/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
+++ b/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
@@ -29,7 +29,6 @@ void main() {
 
   group('getUserTickets', () {
     test(
-      'Test that getUserTickets '
       'returns a [Right] value '
       'when the executor returns a [Right] value',
       () async {
@@ -46,7 +45,6 @@ void main() {
     );
 
     test(
-      'Test that getUserTickets '
       'returns a [Left] value '
       'when the executor returns a [Left] value',
       () async {
@@ -63,7 +61,6 @@ void main() {
     );
 
     test(
-      'Test that getUserTickets '
       'returns a [TicketCountModel] with the count of tickets and joined ticket names '
       'when the executor returns two [TicketResponse] with the same product id '
       'but different product names',
@@ -106,7 +103,6 @@ void main() {
     'useTicket',
     () {
       test(
-        'Test that useTicket '
         'returns a [Right] value '
         'when the executor returns a [Right] value',
         () async {
@@ -131,9 +127,8 @@ void main() {
       );
 
       test(
-        'Test that useTicket '
         'returns a [Left] value '
-        'when the executor returns a [Left] value',
+        'when the executor fails',
         () async {
           // arrange
           when(executor.call<TicketDto>(any))

--- a/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
+++ b/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
@@ -29,8 +29,9 @@ void main() {
 
   group('getUserTickets', () {
     test(
-      'returns a [Right] value '
-      'when the executor returns a [Right] value',
+      'GIVEN executor returns a [Right] value '
+      'WHEN calling getUserTickets '
+      'THEN a [Right] value is returned',
       () async {
         // arrange
         when(executor.call<List<TicketResponse>>(any))
@@ -45,8 +46,9 @@ void main() {
     );
 
     test(
-      'returns a [Left] value '
-      'when the executor returns a [Left] value',
+      'GIVEN executor returns a [Left] value '
+      'WHEN calling getUserTickets '
+      'THEN a [Left] value is returned',
       () async {
         // arrange
         when(executor.call<List<TicketResponse>>(any))
@@ -56,14 +58,14 @@ void main() {
         final actual = await dataSource.getUserTickets();
 
         // assert
-        expect(actual, const Left(ServerFailure('some error')));
+        expect(actual.isLeft(), isTrue);
       },
     );
 
     test(
-      'returns a [TicketCountModel] with the count of tickets and joined ticket names '
-      'when the executor returns two [TicketResponse] with the same product id '
-      'but different product names',
+      'GIVEN executor returns two [TicketResponse] with the same product id but different product names '
+      'WHEN calling getUserTickets '
+      'THEN a [TicketCountModel] with the count of tickets and joined ticket names is returned',
       () async {
         // arrange
         when(executor.call<List<TicketResponse>>(any)).thenAnswer(
@@ -103,8 +105,9 @@ void main() {
     'useTicket',
     () {
       test(
-        'returns a [Right] value '
-        'when the executor returns a [Right] value',
+        'GIVEN executor returns a [Right] value '
+        'WHEN calling useTicket '
+        'THEN a [Right] value is returned',
         () async {
           // arrange
           when(executor.call<TicketDto>(any)).thenAnswer(
@@ -127,8 +130,9 @@ void main() {
       );
 
       test(
-        'returns a [Left] value '
-        'when the executor fails',
+        'GIVEN executor returns a [Left] value '
+        'WHEN calling useTicket '
+        'THEN a [Left] value is returned',
         () async {
           // arrange
           when(executor.call<TicketDto>(any))
@@ -138,7 +142,7 @@ void main() {
           final actual = await dataSource.useTicket(0);
 
           // assert
-          expect(actual, const Left(ServerFailure('some error')));
+          expect(actual.isLeft(), isTrue);
         },
       );
     },

--- a/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
+++ b/test/features/ticket/data/datasources/ticket_remote_data_source_test.dart
@@ -28,62 +28,124 @@ void main() {
   });
 
   group('getUserTickets', () {
-    test('should return [Right] when executor returns [Right]', () async {
-      // arrange
-      when(executor.call<List<TicketResponse>>(any))
-          .thenAnswer((_) async => const Right([]));
+    test(
+      'Test that getUserTickets '
+      'returns a [Right] value '
+      'when the executor returns a [Right] value',
+      () async {
+        // arrange
+        when(executor.call<List<TicketResponse>>(any))
+            .thenAnswer((_) async => const Right([]));
 
-      // act
-      final actual = await dataSource.getUserTickets();
+        // act
+        final actual = await dataSource.getUserTickets();
 
-      // assert
-      expect(actual.isRight(), isTrue);
-    });
+        // assert
+        expect(actual.isRight(), isTrue);
+      },
+    );
 
-    test('should return [Left] if executor returns [Left]', () async {
-      // arrange
-      when(executor.call<List<TicketResponse>>(any))
-          .thenAnswer((_) async => const Left(ServerFailure('some error')));
+    test(
+      'Test that getUserTickets '
+      'returns a [Left] value '
+      'when the executor returns a [Left] value',
+      () async {
+        // arrange
+        when(executor.call<List<TicketResponse>>(any))
+            .thenAnswer((_) async => const Left(ServerFailure('some error')));
 
-      // act
-      final actual = await dataSource.getUserTickets();
+        // act
+        final actual = await dataSource.getUserTickets();
 
-      // assert
-      expect(actual, const Left(ServerFailure('some error')));
-    });
+        // assert
+        expect(actual, const Left(ServerFailure('some error')));
+      },
+    );
+
+    test(
+      'Test that getUserTickets '
+      'returns a [TicketCountModel] with the count of tickets and joined ticket names '
+      'when the executor returns two [TicketResponse] with the same product id '
+      'but different product names',
+      () async {
+        // arrange
+        when(executor.call<List<TicketResponse>>(any)).thenAnswer(
+          (_) async => Right([
+            TicketResponse(
+              id: 0,
+              dateCreated: DateTime.parse('2023-05-23'),
+              dateUsed: null,
+              productId: 0,
+              productName: 'A',
+            ),
+            TicketResponse(
+              id: 0,
+              dateCreated: DateTime.parse('2023-05-23'),
+              dateUsed: null,
+              productId: 0,
+              productName: 'B',
+            ),
+          ]),
+        );
+
+        // act
+        final actual = await dataSource.getUserTickets();
+
+        // assert
+        expect(actual.isRight(), isTrue);
+        final right = actual.getOrElse((_) => []);
+        expect(right, hasLength(1));
+        expect(right.first.productId, equals(0));
+        expect(right.first.count, equals(2));
+        expect(right.first.productName, anyOf(['A/B', 'B/A']));
+      },
+    );
   });
 
-  group('useTicket', () {
-    test('should return [Right] when executor returns [Right]', () async {
-      // arrange
-      when(executor.call<TicketDto>(any)).thenAnswer(
-        (_) async => Right(
-          TicketDto(
-            id: 0,
-            dateCreated: DateTime.parse('2023-04-11'),
-            dateUsed: DateTime.parse('2023-04-11'),
-            productName: 'productName',
-          ),
-        ),
+  group(
+    'useTicket',
+    () {
+      test(
+        'Test that useTicket '
+        'returns a [Right] value '
+        'when the executor returns a [Right] value',
+        () async {
+          // arrange
+          when(executor.call<TicketDto>(any)).thenAnswer(
+            (_) async => Right(
+              TicketDto(
+                id: 0,
+                dateCreated: DateTime.parse('2023-04-11'),
+                dateUsed: DateTime.parse('2023-04-11'),
+                productName: 'productName',
+              ),
+            ),
+          );
+
+          // act
+          final actual = await dataSource.useTicket(0);
+
+          // assert
+          expect(actual.isRight(), isTrue);
+        },
       );
 
-      // act
-      final actual = await dataSource.useTicket(0);
+      test(
+        'Test that useTicket '
+        'returns a [Left] value '
+        'when the executor returns a [Left] value',
+        () async {
+          // arrange
+          when(executor.call<TicketDto>(any))
+              .thenAnswer((_) async => const Left(ServerFailure('some error')));
 
-      // assert
-      expect(actual.isRight(), isTrue);
-    });
+          // act
+          final actual = await dataSource.useTicket(0);
 
-    test('should return [Left] if executor returns [Left]', () async {
-      // arrange
-      when(executor.call<TicketDto>(any))
-          .thenAnswer((_) async => const Left(ServerFailure('some error')));
-
-      // act
-      final actual = await dataSource.useTicket(0);
-
-      // assert
-      expect(actual, const Left(ServerFailure('some error')));
-    });
-  });
+          // assert
+          expect(actual, const Left(ServerFailure('some error')));
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
`CoffeeCard`s are now grouped by id instead of name; if a group has tickets with different names, their names will be joined

Closes #466 