### PR TITLE
fix(receipts): Remove purchase receipt view & refactor payment status display

### DIFF
--- a/lib/base/strings.dart
+++ b/lib/base/strings.dart
@@ -202,6 +202,13 @@ abstract final class Strings {
   static String noReceiptsOfTypeMessage(String buyOrSwipe) =>
       'When you $buyOrSwipe tickets, they will show up here.\nGo to the Tickets tab to $buyOrSwipe tickets.';
 
+  // PaymentStatus enum
+  static const paymentStatusCompleted = 'Purchased';
+  static const paymentStatusRefunded = 'Purchase refunded';
+  static const paymentStatusAwaitingPayment = 'Payment pending';
+  static const paymentStatusReserved = 'Payment reserved';
+  static const paymentStatusFailed = 'Payment failed';
+
   // Statistics page
   static const statsYourStats = 'Your stats';
   static const statsLeaderboards = 'Leaderboards';

--- a/lib/features/purchase/domain/entities/payment_status.dart
+++ b/lib/features/purchase/domain/entities/payment_status.dart
@@ -32,12 +32,12 @@ enum PaymentStatus {
   @override
   String toString() {
     return switch (this) {
-      PaymentStatus.completed => 'Completed',
-      PaymentStatus.rejectedPayment => 'Rejected',
-      PaymentStatus.awaitingPayment => 'Pending',
-      PaymentStatus.refunded => 'Refunded',
-      PaymentStatus.error => 'Error',
-      PaymentStatus.reserved => 'Reserved',
+      PaymentStatus.completed => 'Purchased',
+      PaymentStatus.refunded => 'Purchase refunded',
+      PaymentStatus.rejectedPayment => 'Payment rejected',
+      PaymentStatus.awaitingPayment => 'Payment pending',
+      PaymentStatus.error => 'Payment error',
+      PaymentStatus.reserved => 'Payment reserved',
     };
   }
 }

--- a/lib/features/purchase/domain/entities/payment_status.dart
+++ b/lib/features/purchase/domain/entities/payment_status.dart
@@ -1,3 +1,4 @@
+import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/generated/api/coffeecard_api_v2.enums.swagger.dart';
 
 enum PaymentStatus {
@@ -32,12 +33,13 @@ enum PaymentStatus {
   @override
   String toString() {
     return switch (this) {
-      PaymentStatus.completed => 'Purchased',
-      PaymentStatus.refunded => 'Purchase refunded',
-      PaymentStatus.rejectedPayment => 'Payment rejected',
-      PaymentStatus.awaitingPayment => 'Payment pending',
-      PaymentStatus.error => 'Payment error',
-      PaymentStatus.reserved => 'Payment reserved',
+      PaymentStatus.completed => Strings.paymentStatusCompleted,
+      PaymentStatus.refunded => Strings.paymentStatusRefunded,
+      PaymentStatus.awaitingPayment => Strings.paymentStatusAwaitingPayment,
+      PaymentStatus.reserved => Strings.paymentStatusReserved,
+      PaymentStatus.rejectedPayment ||
+      PaymentStatus.error =>
+        Strings.paymentStatusFailed,
     };
   }
 }

--- a/lib/features/purchase/presentation/pages/buy_tickets_page.dart
+++ b/lib/features/purchase/presentation/pages/buy_tickets_page.dart
@@ -121,7 +121,7 @@ class BuyTicketsPage extends StatelessWidget {
         ReceiptOverlay.of(context).show(
           isTestEnvironment:
               envState is EnvironmentLoaded && envState.env.isTest,
-          paymentStatus: Strings.purchased,
+          status: Strings.purchased,
           productName: payment.productName,
           timeUsed: payment.purchaseTime,
         );

--- a/lib/features/receipt/presentation/pages/view_receipt_page.dart
+++ b/lib/features/receipt/presentation/pages/view_receipt_page.dart
@@ -34,7 +34,7 @@ class ViewReceiptPage extends StatelessWidget {
                   isInOverlay: false,
                   isTestEnvironment:
                       state is EnvironmentLoaded && state.env.isTest,
-                  paymentStatus: paymentStatus,
+                  status: paymentStatus,
                 ),
               ],
             ),

--- a/lib/features/receipt/presentation/widgets/list_entry/placeholder_receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/placeholder_receipt_list_entry.dart
@@ -16,7 +16,7 @@ class PlaceholderReceiptListEntry extends StatelessWidget {
       topText: Strings.receiptPlaceholderName,
       rightText: Strings.oneTicket,
       backgroundColor: Colors.transparent,
-      purchaseStatus: '',
+      status: '',
     );
   }
 }

--- a/lib/features/receipt/presentation/widgets/list_entry/purchase_receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/purchase_receipt_list_entry.dart
@@ -1,3 +1,4 @@
+import 'package:coffeecard/base/strings.dart';
 import 'package:coffeecard/base/style/colors.dart';
 import 'package:coffeecard/features/purchase/domain/entities/payment_status.dart';
 import 'package:coffeecard/features/receipt/domain/entities/receipt.dart';
@@ -12,13 +13,13 @@ class PurchaseReceiptListEntry extends StatelessWidget {
   });
 
   String get priceText {
-    final price = receipt.price;
+    final price = Strings.price(receipt.price);
     return switch (receipt.paymentStatus) {
-      PaymentStatus.completed => '$price,-',
+      PaymentStatus.completed => price,
       PaymentStatus.awaitingPayment ||
       PaymentStatus.reserved ||
       PaymentStatus.refunded =>
-        '($price,-)',
+        '($price)',
       PaymentStatus.error || PaymentStatus.rejectedPayment => '',
     };
   }

--- a/lib/features/receipt/presentation/widgets/list_entry/purchase_receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/purchase_receipt_list_entry.dart
@@ -1,4 +1,5 @@
 import 'package:coffeecard/base/style/colors.dart';
+import 'package:coffeecard/features/purchase/domain/entities/payment_status.dart';
 import 'package:coffeecard/features/receipt/domain/entities/receipt.dart';
 import 'package:coffeecard/features/receipt/presentation/widgets/list_entry/receipt_list_entry.dart';
 import 'package:flutter/material.dart';
@@ -10,18 +11,32 @@ class PurchaseReceiptListEntry extends StatelessWidget {
     required this.receipt,
   });
 
+  String get priceText {
+    final price = receipt.price;
+    return switch (receipt.paymentStatus) {
+      PaymentStatus.completed => '$price,-',
+      PaymentStatus.awaitingPayment ||
+      PaymentStatus.reserved ||
+      PaymentStatus.refunded =>
+        '($price,-)',
+      PaymentStatus.error || PaymentStatus.rejectedPayment => '',
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     return ReceiptListEntry(
-      tappable: true,
+      tappable: false,
       name: receipt.productName,
       time: receipt.timeUsed,
       isPurchase: true,
       showShimmer: false,
       topText: '${receipt.amountPurchased} ${receipt.productName}',
-      rightText: '${receipt.price},-',
-      backgroundColor: AppColor.slightlyHighlighted,
-      purchaseStatus: '${receipt.paymentStatus}',
+      rightText: priceText,
+      backgroundColor: receipt.paymentStatus == PaymentStatus.completed
+          ? AppColor.slightlyHighlighted
+          : AppColor.lightGray.withOpacity(0.5),
+      status: '${receipt.paymentStatus}',
     );
   }
 }

--- a/lib/features/receipt/presentation/widgets/list_entry/receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/receipt_list_entry.dart
@@ -6,7 +6,7 @@ import 'package:coffeecard/widgets/components/list_entry.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-final _formatter = DateFormat('dd.MM.yyyy');
+final _formatDate = DateFormat('dd.MM.yyyy').format;
 
 class ReceiptListEntry extends StatelessWidget {
   final bool tappable;
@@ -17,7 +17,7 @@ class ReceiptListEntry extends StatelessWidget {
   final String topText;
   final String rightText;
   final Color backgroundColor;
-  final String purchaseStatus;
+  final String status;
 
   const ReceiptListEntry({
     required this.tappable,
@@ -28,18 +28,20 @@ class ReceiptListEntry extends StatelessWidget {
     required this.topText,
     required this.rightText,
     required this.backgroundColor,
-    required this.purchaseStatus,
+    required this.status,
   });
 
   @override
   Widget build(BuildContext context) {
     return OpenContainer(
       tappable: tappable,
+      // Remove rounded edges
+      closedShape: const RoundedRectangleBorder(),
       openBuilder: (context, _) {
         return ViewReceiptPage(
           name: name,
           time: time,
-          paymentStatus: purchaseStatus,
+          paymentStatus: status,
         );
       },
       closedBuilder: (context, openContainer) {
@@ -61,7 +63,7 @@ class ReceiptListEntry extends StatelessWidget {
                   ColoredBox(
                     color: colorIfShimmer,
                     child: Text(
-                      '$purchaseStatus ${_formatter.format(time)}',
+                      '$status ${_formatDate(time)}',
                       style: AppTextStyle.receiptItemDate,
                     ),
                   ),

--- a/lib/features/receipt/presentation/widgets/list_entry/receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/receipt_list_entry.dart
@@ -1,4 +1,5 @@
 import 'package:animations/animations.dart';
+import 'package:coffeecard/base/style/colors.dart';
 import 'package:coffeecard/base/style/text_styles.dart';
 import 'package:coffeecard/features/receipt/presentation/pages/view_receipt_page.dart';
 import 'package:coffeecard/widgets/components/helpers/shimmer_builder.dart';
@@ -6,7 +7,7 @@ import 'package:coffeecard/widgets/components/list_entry.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-final _formatDate = DateFormat('dd.MM.yyyy').format;
+final _formatDateTime = DateFormat('dd/MM/y HH:mm').format;
 
 class ReceiptListEntry extends StatelessWidget {
   final bool tappable;
@@ -31,8 +32,16 @@ class ReceiptListEntry extends StatelessWidget {
     required this.status,
   });
 
+  TextStyle get statusTextStyle {
+    return tappable
+        ? AppTextStyle.receiptItemDate
+        : AppTextStyle.receiptItemDate.copyWith(color: AppColor.gray);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final time = this.time.toLocal();
+
     return OpenContainer(
       tappable: tappable,
       // Remove rounded edges
@@ -63,8 +72,15 @@ class ReceiptListEntry extends StatelessWidget {
                   ColoredBox(
                     color: colorIfShimmer,
                     child: Text(
-                      '$status ${_formatDate(time)}',
-                      style: AppTextStyle.receiptItemDate,
+                      status,
+                      style: statusTextStyle,
+                    ),
+                  ),
+                  ColoredBox(
+                    color: colorIfShimmer,
+                    child: Text(
+                      _formatDateTime(time),
+                      style: statusTextStyle,
                     ),
                   ),
                 ],

--- a/lib/features/receipt/presentation/widgets/list_entry/swipe_receipt_list_entry.dart
+++ b/lib/features/receipt/presentation/widgets/list_entry/swipe_receipt_list_entry.dart
@@ -20,7 +20,7 @@ class SwipeReceiptListEntry extends StatelessWidget {
       topText: receipt.productName,
       rightText: Strings.oneTicket,
       backgroundColor: AppColor.white,
-      purchaseStatus: Strings.swiped,
+      status: Strings.swiped,
     );
   }
 }

--- a/lib/features/receipt/presentation/widgets/receipt_card.dart
+++ b/lib/features/receipt/presentation/widgets/receipt_card.dart
@@ -9,21 +9,21 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:intl/intl.dart';
 
-DateFormat get _formatter => DateFormat('EEEE d/M/y HH:mm');
+final _formatDate = DateFormat('EEEE d/M/y HH:mm').format;
 
 class ReceiptCard extends StatelessWidget {
   final String productName;
   final DateTime time;
   final bool isInOverlay;
   final bool isTestEnvironment;
-  final String paymentStatus;
+  final String status;
 
   const ReceiptCard({
     required this.productName,
     required this.time,
     required this.isInOverlay,
     required this.isTestEnvironment,
-    required this.paymentStatus,
+    required this.status,
   });
 
   @override
@@ -39,7 +39,7 @@ class ReceiptCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              paymentStatus,
+              status,
               style: AppTextStyle.textField,
             ),
             const Gap(16),
@@ -50,7 +50,7 @@ class ReceiptCard extends StatelessWidget {
               style: AppTextStyle.textFieldBold,
             ),
             Text(
-              _formatter.format(localTime),
+              _formatDate(localTime),
               style: AppTextStyle.textField,
             ),
           ],

--- a/lib/features/receipt/presentation/widgets/receipt_overlay.dart
+++ b/lib/features/receipt/presentation/widgets/receipt_overlay.dart
@@ -19,7 +19,7 @@ class ReceiptOverlay {
     required String productName,
     required DateTime timeUsed,
     required bool isTestEnvironment,
-    required String paymentStatus,
+    required String status,
   }) async {
     await ScreenBrightness().setScreenBrightness(1);
     if (_context.mounted) {
@@ -38,7 +38,7 @@ class ReceiptOverlay {
                     time: timeUsed,
                     isInOverlay: true,
                     isTestEnvironment: isTestEnvironment,
-                    status: paymentStatus,
+                    status: status,
                   ),
                   const Gap(12),
                   Text(

--- a/lib/features/receipt/presentation/widgets/receipt_overlay.dart
+++ b/lib/features/receipt/presentation/widgets/receipt_overlay.dart
@@ -38,7 +38,7 @@ class ReceiptOverlay {
                     time: timeUsed,
                     isInOverlay: true,
                     isTestEnvironment: isTestEnvironment,
-                    paymentStatus: paymentStatus,
+                    status: paymentStatus,
                   ),
                   const Gap(12),
                   Text(

--- a/lib/features/ticket/presentation/widgets/tickets_section.dart
+++ b/lib/features/ticket/presentation/widgets/tickets_section.dart
@@ -49,7 +49,7 @@ class TicketSection extends StatelessWidget {
               ReceiptOverlay.of(context).show(
                 isTestEnvironment:
                     envState is EnvironmentLoaded && envState.env.isTest,
-                paymentStatus: state.receipt is PurchaseReceipt
+                status: state.receipt is PurchaseReceipt
                     ? (state.receipt as PurchaseReceipt)
                         .paymentStatus
                         .toString()


### PR DESCRIPTION
Closes #477.
- `PurchaseReceiptListEntry` widget now has 'tappable' set to false, disabling purchase receipts.
- Timestamp has been added below the purchase/swipe status in `ReceiptListEntry`.
- Updated `PaymentStatus` string values to provide clearer descriptions.
- Renamed 'purchaseStatus' field to 'status' across multiple generic receipt widgets.
- Refactored `PurchaseReceiptListEntry` to show price differently (or hide it), based on status.
- misc: Updated `_formatter` to `_formatDate`/`_formatDateTime` in `ReceiptListEntry` and `ReceiptCard`.
- misc: Removed rounded edges from `ReceiptListEntry`.