### PR TITLE
Fix widget emitting state after close

### DIFF
--- a/lib/core/widgets/pages/splash/splash_loading_page.dart
+++ b/lib/core/widgets/pages/splash/splash_loading_page.dart
@@ -21,7 +21,11 @@ class _SplashLoadingPageState extends State<SplashLoadingPage> {
     super.initState();
     Timer(
       timeBeforeShowLoadingIndicator,
-      () => setState(() => showLoadingIndicator = true),
+      () {
+        if (mounted) {
+          setState(() => showLoadingIndicator = true);
+        }
+      },
     );
   }
 


### PR DESCRIPTION
Splash loading indicator throws an exception if the timer expires and the widget is not mounted