### PR TITLE
Fix email validation logic in Forgot Passcode page

### DIFF
--- a/lib/features/login/presentation/widgets/forgot_passcode_form.dart
+++ b/lib/features/login/presentation/widgets/forgot_passcode_form.dart
@@ -28,14 +28,14 @@ class ForgotPasscodeForm extends StatelessWidget {
         InputValidator(
           forceErrorMessage: true,
           validate: (text) async {
-            final either =
+            final emailExistsResult =
                 await sl<AccountRemoteDataSource>().emailExists(text);
 
-            return either.fold(
-              (l) => const Left(Strings.emailValidationError),
-              (r) => r
-                  ? const Left(Strings.forgotPasscodeNoAccountExists)
-                  : const Right(null),
+            return emailExistsResult.fold(
+              (error) => const Left(Strings.emailValidationError),
+              (emailExists) => emailExists
+                  ? const Right(null)
+                  : const Left(Strings.forgotPasscodeNoAccountExists),
             );
           },
         ),


### PR DESCRIPTION
Inverted an if-else that would determine whether to show the "no account exists" error or not.

Fix #520