### PR TITLE
Fix Android appbundle artifact name

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -55,4 +55,4 @@ jobs:
           # FIXME: token is deprecated, use serviceCredentialsFileContent instead
           # serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: analogio-devs
-          file: app-development-release.apk
+          file: android.aab


### PR DESCRIPTION
Note: the [prod version](https://github.com/AnalogIO/coffeecard_app/blob/main/.github/workflows/release-prod.yml) does not look like it needs any update. If I am mistaken, please correct this PR