### PR TITLE
refactor: Option type and TimeOfDay in opening hours

### DIFF
--- a/lib/core/external/date_service.dart
+++ b/lib/core/external/date_service.dart
@@ -1,6 +1,3 @@
 class DateService {
-  DateTime now() => DateTime.now();
-  int currentWeekday() => now().weekday;
-  int currentHour() => now().hour;
-  int currentMinute() => now().minute;
+  DateTime get currentDateTime => DateTime.now();
 }

--- a/lib/features/opening_hours/data/datasources/opening_hours_local_data_source.dart
+++ b/lib/features/opening_hours/data/datasources/opening_hours_local_data_source.dart
@@ -1,21 +1,21 @@
 import 'package:coffeecard/features/opening_hours/domain/entities/timeslot.dart';
+import 'package:flutter/material.dart';
 
 class OpeningHoursLocalDataSource {
   Map<int, Timeslot> getOpeningHours() {
-    const open = (8, 0);
+    const openTime = TimeOfDay(hour: 8, minute: 0);
+    const normalDayCloseTime = TimeOfDay(hour: 15, minute: 30);
+    const shortDayCloseTime = TimeOfDay(hour: 13, minute: 30);
 
-    const normalOperation = Timeslot(start: open, end: (15, 30));
-    const shortDayOperation = Timeslot(start: open, end: (14, 30));
-    const closed = Timeslot();
+    const normalDayOpeningHours = Timeslot(openTime, normalDayCloseTime);
+    const shortDayOpeningHours = Timeslot(openTime, shortDayCloseTime);
 
     return {
-      DateTime.monday: normalOperation,
-      DateTime.tuesday: normalOperation,
-      DateTime.wednesday: normalOperation,
-      DateTime.thursday: normalOperation,
-      DateTime.friday: shortDayOperation,
-      DateTime.saturday: closed,
-      DateTime.sunday: closed,
+      DateTime.monday: normalDayOpeningHours,
+      DateTime.tuesday: normalDayOpeningHours,
+      DateTime.wednesday: normalDayOpeningHours,
+      DateTime.thursday: normalDayOpeningHours,
+      DateTime.friday: shortDayOpeningHours,
     };
   }
 }

--- a/lib/features/opening_hours/domain/entities/opening_hours.dart
+++ b/lib/features/opening_hours/domain/entities/opening_hours.dart
@@ -1,9 +1,10 @@
 import 'package:coffeecard/features/opening_hours/domain/entities/timeslot.dart';
 import 'package:equatable/equatable.dart';
+import 'package:fpdart/fpdart.dart';
 
 class OpeningHours extends Equatable {
   final Map<int, Timeslot> allOpeningHours;
-  final Timeslot todaysOpeningHours;
+  final Option<Timeslot> todaysOpeningHours;
 
   const OpeningHours({
     required this.allOpeningHours,

--- a/lib/features/opening_hours/domain/entities/timeslot.dart
+++ b/lib/features/opening_hours/domain/entities/timeslot.dart
@@ -1,33 +1,37 @@
-import 'package:coffeecard/core/strings.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
 
+/// A timeslot with a start and end time.
 class Timeslot extends Equatable {
-  final (int, int)? start;
-  final (int, int)? end;
+  final TimeOfDay startTime;
+  final TimeOfDay endTime;
 
-  const Timeslot({this.start, this.end});
+  const Timeslot(this.startTime, this.endTime);
 
-  bool get isClosed => start == null || end == null;
+  String format(BuildContext context) {
+    final start = startTime.format(context);
+    final end = endTime.format(context);
+    return '$start-$end';
+  }
 
   @override
-  String toString() {
-    if (isClosed) {
-      return Strings.closed;
+  List<Object?> get props => [startTime, endTime];
+}
+
+/// Operators for comparing [TimeOfDay]s.
+extension TimeOfDayOperators on TimeOfDay {
+  /// Returns true if [other] is before [this].
+  bool operator <=(TimeOfDay other) {
+    if (hour < other.hour) {
+      return true;
+    } else if (hour == other.hour) {
+      return minute <= other.minute;
+    } else {
+      return false;
     }
-
-    final startMinute = _pad(start!.$2.toString());
-    final startHor = _pad(start!.$1.toString());
-
-    final endMinute = _pad(end!.$2.toString());
-    final endHour = _pad(end!.$1.toString());
-
-    return '$startHor:$startMinute - $endHour:$endMinute';
   }
 
-  String _pad(String s) {
-    return s.padLeft(2, '0');
+  bool isInTimeslot(Timeslot timeslot) {
+    return timeslot.startTime <= this && this <= timeslot.endTime;
   }
-
-  @override
-  List<Object?> get props => [start, end];
 }

--- a/lib/features/opening_hours/presentation/cubit/opening_hours_cubit.dart
+++ b/lib/features/opening_hours/presentation/cubit/opening_hours_cubit.dart
@@ -3,6 +3,7 @@ import 'package:coffeecard/features/opening_hours/domain/entities/timeslot.dart'
 import 'package:coffeecard/features/opening_hours/domain/usecases/check_open_status.dart';
 import 'package:coffeecard/features/opening_hours/domain/usecases/get_opening_hours.dart';
 import 'package:equatable/equatable.dart';
+import 'package:fpdart/fpdart.dart';
 
 part 'opening_hours_state.dart';
 

--- a/lib/features/opening_hours/presentation/cubit/opening_hours_state.dart
+++ b/lib/features/opening_hours/presentation/cubit/opening_hours_state.dart
@@ -13,7 +13,7 @@ class OpeningHoursInitial extends OpeningHoursState {
 
 class OpeningHoursLoaded extends OpeningHoursState {
   final Map<int, Timeslot> openingHours;
-  final Timeslot todaysOpeningHours;
+  final Option<Timeslot> todaysOpeningHours;
   final bool isOpen;
 
   const OpeningHoursLoaded({

--- a/lib/features/opening_hours/presentation/pages/opening_hours_page.dart
+++ b/lib/features/opening_hours/presentation/pages/opening_hours_page.dart
@@ -16,11 +16,6 @@ class OpeningHoursPage extends StatelessWidget {
     return MaterialPageRoute(builder: (_) => OpeningHoursPage(state: state));
   }
 
-  List<MapEntry<int, Timeslot>> get openingHours {
-    return state.openingHours.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
-  }
-
   @override
   Widget build(BuildContext context) {
     return AppScaffold.withTitle(
@@ -37,7 +32,7 @@ class OpeningHoursPage extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                _OpeningHoursView(openingHours: openingHours),
+                _OpeningHoursView(openingHours: state.openingHours),
                 const Gap(36),
                 Row(
                   children: [
@@ -65,18 +60,20 @@ class OpeningHoursPage extends StatelessWidget {
 class _OpeningHoursView extends StatelessWidget {
   const _OpeningHoursView({required this.openingHours});
 
-  final List<MapEntry<int, Timeslot>> openingHours;
+  final Map<int, Timeslot> openingHours;
 
   @override
   Widget build(BuildContext context) {
     return ListView.separated(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
-      itemCount: openingHours.length,
+      itemCount: Strings.weekdaysPlural.length,
       separatorBuilder: (_, __) => const Gap(12),
-      itemBuilder: (context, index) {
-        final weekday = openingHours[index].key;
-        final hours = openingHours[index].value;
+      itemBuilder: (_, weekday) {
+        final hours = switch (openingHours[weekday]) {
+          final Timeslot timeslot => timeslot.format(context),
+          _ => Strings.closed,
+        };
 
         return Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -85,7 +82,10 @@ class _OpeningHoursView extends StatelessWidget {
               Strings.weekdaysPlural[weekday]!,
               style: AppTextStyle.settingKey,
             ),
-            Text(hours.toString(), style: AppTextStyle.receiptItemKey),
+            Text(
+              hours,
+              style: AppTextStyle.receiptItemKey,
+            ),
           ],
         );
       },

--- a/lib/features/opening_hours/presentation/pages/opening_hours_page.dart
+++ b/lib/features/opening_hours/presentation/pages/opening_hours_page.dart
@@ -69,7 +69,8 @@ class _OpeningHoursView extends StatelessWidget {
       physics: const NeverScrollableScrollPhysics(),
       itemCount: Strings.weekdaysPlural.length,
       separatorBuilder: (_, __) => const Gap(12),
-      itemBuilder: (_, weekday) {
+      itemBuilder: (_, index) {
+        final weekday = index + 1;
         final hours = switch (openingHours[weekday]) {
           final Timeslot timeslot => timeslot.format(context),
           _ => Strings.closed,

--- a/test/features/opening_hours/domain/usecases/get_opening_hours_test.dart
+++ b/test/features/opening_hours/domain/usecases/get_opening_hours_test.dart
@@ -26,8 +26,10 @@ void main() {
 
   test('should return opening hours', () async {
     // arrange
-    const theOpeningHours =
-        OpeningHours(allOpeningHours: {}, todaysOpeningHours: Timeslot());
+    const theOpeningHours = OpeningHours(
+      allOpeningHours: {},
+      todaysOpeningHours: Option.none(),
+    );
 
     when(repository.getOpeningHours()).thenReturn(
       theOpeningHours,

--- a/test/features/opening_hours/presentation/cubit/opening_hours_cubit_test.dart
+++ b/test/features/opening_hours/presentation/cubit/opening_hours_cubit_test.dart
@@ -35,8 +35,10 @@ void main() {
   });
 
   group('getOpeninghours', () {
-    const theOpeningHours =
-        OpeningHours(allOpeningHours: {}, todaysOpeningHours: Timeslot());
+    const theOpeningHours = OpeningHours(
+      allOpeningHours: {},
+      todaysOpeningHours: Option.none(),
+    );
     const isOpen = true;
 
     blocTest(


### PR DESCRIPTION
Uses the flutter-native TimeOfDay class, which has localized time formatting.
This has been extended with comparison methods <= and isInTimeslot.
Timeslot class simplifies with this change.

Simplify DateService to only contain one getter.

Make sure of fpdart's Option instead of null values. Use None for closed days.

Clean up tests and use NiceMocks for mocking.