### PR TITLE
Sign apk builds

### DIFF
--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -67,11 +67,20 @@ runs:
         keyStorePassword: ${{ inputs.keyStorePassword }}
         keyPassword: ${{ inputs.keyPassword }}
 
-    - name: Upload artifact
-      if: ${{ !!inputs.store_artifacts }}
+    - name: Upload appbundle
+      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android
-        path: ${{steps.sign_app.outputs.signedReleaseFile}}
+        path: "${{steps.sign_app.outputs.signedReleaseFile}}/android-signed.aab"
+        retention-days: 1
+        if-no-files-found: error
+
+    - name: Upload apk
+      if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
+      uses: actions/upload-artifact@v3.1.3
+      with:
+        name: android
+        path: "${{steps.sign_app.outputs.signedReleaseFile}}/android-signed.apk"
         retention-days: 1
         if-no-files-found: error

--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -78,7 +78,7 @@ runs:
       if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
-        name: android.aab
+        name: android
         path: android.aab
         retention-days: 1
         if-no-files-found: error
@@ -93,7 +93,7 @@ runs:
       if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
-        name: android.apk
+        name: android
         path: android.apk
         retention-days: 1
         if-no-files-found: error

--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -78,7 +78,7 @@ runs:
       if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
-        name: android
+        name: android.aab
         path: android.aab
         retention-days: 1
         if-no-files-found: error
@@ -93,7 +93,7 @@ runs:
       if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
-        name: android
+        name: android.apk
         path: android.apk
         retention-days: 1
         if-no-files-found: error

--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -58,6 +58,7 @@ runs:
       shell: bash
 
     - name: Sign artifact
+      if: ${{ !!inputs.store_artifacts }}
       uses: r0adkll/sign-android-release@v1.0.4
       id: sign_app
       with:
@@ -67,20 +68,32 @@ runs:
         keyStorePassword: ${{ inputs.keyStorePassword }}
         keyPassword: ${{ inputs.keyPassword }}
 
+    - name: Move appbundle
+      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
+      run: |
+        mv ${{steps.sign_app.outputs.signedReleaseFile}} android.aab
+      shell: bash
+
     - name: Upload appbundle
       if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android
-        path: "${{steps.sign_app.outputs.signedReleaseFile}}/android-signed.aab"
+        path: android.aab
         retention-days: 1
         if-no-files-found: error
+
+    - name: Move apk
+      if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
+      run: |
+        mv ${{steps.sign_app.outputs.signedReleaseFile}} android.apk
+      shell: bash
 
     - name: Upload apk
       if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android
-        path: "${{steps.sign_app.outputs.signedReleaseFile}}/android-signed.apk"
+        path: android.apk
         retention-days: 1
         if-no-files-found: error

--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -16,6 +16,18 @@ inputs:
     options:
     - dev
     - prod
+  signingKeyBase64:
+    required: true
+    description: "Android signing key b64"
+  alias:
+    required: true
+    description: "Android key alias"
+  keyStorePassword:
+    required: true
+    description: "Android keystore password"
+  keyPassword:
+    required: true
+    description: "Android key password"
 
 runs:
   using: "composite"
@@ -38,15 +50,6 @@ runs:
         mv build/app/outputs/flutter-apk/app-development-release.apk android.apk
       shell: bash
 
-    - name: Upload apk (dev)
-      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'dev'}}
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        name: android
-        path: android.apk
-        retention-days: 1
-        if-no-files-found: error
-
     - name: Build appbundle (prod)
       if: ${{ inputs.build_type == 'prod' }}
       run: |
@@ -54,11 +57,21 @@ runs:
         mv build/app/outputs/bundle/productionRelease/app-production-release.aab android.aab
       shell: bash
 
-    - name: Upload appbundle (prod)
-      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
+    - name: Sign artifact
+      uses: r0adkll/sign-android-release@v1.0.4
+      id: sign_app
+      with:
+        releaseDirectory: .
+        signingKeyBase64: ${{ inputs.signingKeyBase64 }}
+        alias: ${{ inputs.alias }}
+        keyStorePassword: ${{ inputs.keyStorePassword }}
+        keyPassword: ${{ inputs.keyPassword }}
+
+    - name: Upload artifact
+      if: ${{ !!inputs.store_artifacts }}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android
-        path: android.aab
+        path: ${{steps.sign_app.outputs.signedReleaseFile}}
         retention-days: 1
         if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,3 +92,7 @@ jobs:
           build_version: ${{ needs.version.outputs.build_version }}
           store_artifacts: ${{ inputs.store_artifacts }}
           build_type: ${{ inputs.build_type }}
+          signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE }}
+          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,19 +51,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
 
-      - name: Build iOS app (dev)
-        if: ${{ inputs.build_type != 'prod' }}
-        uses: ./.github/actions/build_ios
-        with:
-          version: ${{ needs.version.outputs.version }}
-          build_version: ${{ needs.version.outputs.build_version }}
-          apple_ios_signing_cert: ${{ secrets.APPLE_IOS_SIGNING_CERTIFICATE_DEVELOPMENT }}
-          apple_ios_signing_cert_pw: ${{ secrets.APPLE_IOS_SIGNING_CERTIFICATE_DEVELOPMENT_PASSWORD }}
-          apple_ios_provisioning_profile: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE_DEVELOPMENT }}
-          apple_keychain_pw: ${{ secrets.APPLE_KEYCHAIN_PW }}
-          store_artifacts: ${{ inputs.store_artifacts }}
-          build_type: ${{ inputs.build_type }}
-
       - name: Build iOS app (prod)
         if: ${{ inputs.build_type == 'prod' }}
         uses: ./.github/actions/build_ios

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
 
+      - name: Build iOS app (dev)
+        if: ${{ inputs.build_type != 'prod' }}
+        uses: ./.github/actions/build_ios
+        with:
+          version: ${{ needs.version.outputs.version }}
+          build_version: ${{ needs.version.outputs.build_version }}
+          apple_ios_signing_cert: ${{ secrets.APPLE_IOS_SIGNING_CERTIFICATE_DEVELOPMENT }}
+          apple_ios_signing_cert_pw: ${{ secrets.APPLE_IOS_SIGNING_CERTIFICATE_DEVELOPMENT_PASSWORD }}
+          apple_ios_provisioning_profile: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE_DEVELOPMENT }}
+          apple_keychain_pw: ${{ secrets.APPLE_KEYCHAIN_PW }}
+          store_artifacts: ${{ inputs.store_artifacts }}
+          build_type: ${{ inputs.build_type }}
+
       - name: Build iOS app (prod)
         if: ${{ inputs.build_type == 'prod' }}
         uses: ./.github/actions/build_ios

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -16,6 +16,31 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
+  upload_ios:
+    name: Upload iOS build to Firebase App Distribution
+    runs-on: ubuntu-latest
+    needs: [build, test]
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: ios
+
+      - name: Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
+        with:
+          appId: ${{ secrets.FIREBASE_IOS_APP_ID }}
+          token: ${{ secrets.FIREBASE_TOKEN }}
+          # FIXME: token is deprecated, use serviceCredentialsFileContent instead
+          # serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: analogio-devs
+          file: Analog.ipa
+          releaseNotes: |
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.html_url }}
+            (branch ${{ github.head_ref }})
+
   upload_android:
     name: Upload Android build to Firebase App Distribution
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: android.apk
+          name: android
 
       - name: Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -56,4 +56,4 @@ jobs:
           # FIXME: token is deprecated, use serviceCredentialsFileContent instead
           # serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: analogio-devs
-          file: android.apk
+          file: android

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -16,31 +16,6 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
-  upload_ios:
-    name: Upload iOS build to Firebase App Distribution
-    runs-on: ubuntu-latest
-    needs: [build, test]
-
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: ios
-
-      - name: Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
-        with:
-          appId: ${{ secrets.FIREBASE_IOS_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          # FIXME: token is deprecated, use serviceCredentialsFileContent instead
-          # serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
-          groups: analogio-devs
-          file: Analog.ipa
-          releaseNotes: |
-            ${{ github.event.pull_request.title }}
-            ${{ github.event.pull_request.html_url }}
-            (branch ${{ github.head_ref }})
-
   upload_android:
     name: Upload Android build to Firebase App Distribution
     runs-on: ubuntu-latest
@@ -50,7 +25,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: android
+          name: android.apk
 
       - name: Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
@@ -60,7 +35,7 @@ jobs:
           # FIXME: token is deprecated, use serviceCredentialsFileContent instead
           # serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: analogio-devs
-          file: android
+          file: android.apk
           releaseNotes: |
             ${{ github.event.pull_request.title }}
             ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -43,13 +43,13 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: android
+          name: android.aab
 
       - name: Upload to Google Play Store
         uses: r0adkll/upload-google-play@v1.1.2
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAYSTORE_SERVICE_ACCOUNT_JSON }}
           packageName: dk.analog.digitalclipcard
-          releaseFiles: android
+          releaseFiles: android.aab
           track: internal
           status: draft

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -45,21 +45,11 @@ jobs:
         with:
           name: android
 
-      - name: Sign Android appbundle
-        uses: r0adkll/sign-android-release@v1.0.4
-        id: sign_app
-        with:
-          releaseDirectory: .
-          signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE }}
-          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
-          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-
       - name: Upload to Google Play Store
         uses: r0adkll/upload-google-play@v1.1.2
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAYSTORE_SERVICE_ACCOUNT_JSON }}
           packageName: dk.analog.digitalclipcard
-          releaseFiles: ${{ steps.sign_app.outputs.signedReleaseFile }}
+          releaseFiles: android
           track: internal
           status: draft

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v3.0.2
         with:
-          name: android.aab
+          name: android
 
       - name: Upload to Google Play Store
         uses: r0adkll/upload-google-play@v1.1.2


### PR DESCRIPTION
When removing debug signing as done in #542 apk builds from firebase fails to install. This PR ensures both Appbundles and APKs are signed