### PR TITLE
fix(ci): development version built in release pipeline

### DIFF
--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -10,12 +10,6 @@ inputs:
   store_artifacts:
     required: false
     description: "Store artifact"
-  build_type:
-    required: false
-    default: "dev"
-    options:
-      - dev
-      - prod
   signingKeyBase64:
     required: true
     description: "Android signing key b64"
@@ -28,10 +22,23 @@ inputs:
   keyPassword:
     required: true
     description: "Android key password"
+  build_type:
+    required: true
+    description: >
+      Whether to build a development or production version of the app.
+      A 'development' build connects to the development backend for testing,
+      while a 'production' build connects to the production backend.
+      It is an error to specify a build type other than
+      'development' or 'production'.
 
 runs:
   using: "composite"
   steps:
+    - name: Validate build_type
+      uses: ./.github/actions/verify_build_type
+      with:
+        build_type: ${{ inputs.build_type }}
+
     - name: Setup Java
       uses: actions/setup-java@v3.13.0
       with:
@@ -41,17 +48,17 @@ runs:
     - name: Setup Flutter environment
       uses: ./.github/actions/setup_flutter_environment
       with:
-        prod_release: ${{ inputs.build_type == 'prod' }}
+        build_type: ${{ inputs.build_type }}
 
-    - name: Build apk (dev)
-      if: ${{ inputs.build_type == 'dev' }}
+    - name: "[dev] Build Android app (apk)"
+      if: ${{ inputs.build_type == 'development' }}
       run: |
         flutter build apk --flavor development --release --build-name ${{ inputs.version }} --build-number ${{ inputs.build_version }} --target lib/main_development.dart
         mv build/app/outputs/flutter-apk/app-development-release.apk android.apk
       shell: bash
 
-    - name: Build appbundle (prod)
-      if: ${{ inputs.build_type == 'prod' }}
+    - name: "[prod] Build Android app (app bundle)"
+      if: ${{ inputs.build_type == 'production' }}
       run: |
         flutter build appbundle --flavor production --release --build-name ${{ inputs.version }} --build-number ${{ inputs.build_version }} --target lib/main_production.dart
         mv build/app/outputs/bundle/productionRelease/app-production-release.aab android.aab
@@ -68,8 +75,8 @@ runs:
         keyStorePassword: ${{ inputs.keyStorePassword }}
         keyPassword: ${{ inputs.keyPassword }}
 
-    - name: Upload appbundle
-      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'prod'}}
+    - name: "[prod] Upload app bundle"
+      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'production'}}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android
@@ -77,14 +84,14 @@ runs:
         retention-days: 1
         if-no-files-found: error
 
-    - name: Move apk
-      if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
+    - name: "[dev] Move apk file"
+      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'development'}}
       run: |
         mv ${{steps.sign_app.outputs.signedReleaseFile}} android.apk
       shell: bash
 
-    - name: Upload apk
-      if: ${{ !!inputs.store_artifacts && inputs.build_type != 'prod'}}
+    - name: "[dev] Upload apk"
+      if: ${{ !!inputs.store_artifacts && inputs.build_type == 'development'}}
       uses: actions/upload-artifact@v3.1.3
       with:
         name: android

--- a/.github/actions/build_android/action.yml
+++ b/.github/actions/build_android/action.yml
@@ -14,8 +14,8 @@ inputs:
     required: false
     default: "dev"
     options:
-    - dev
-    - prod
+      - dev
+      - prod
   signingKeyBase64:
     required: true
     description: "Android signing key b64"
@@ -41,7 +41,7 @@ runs:
     - name: Setup Flutter environment
       uses: ./.github/actions/setup_flutter_environment
       with:
-        prod_release: ${{ inputs.prod_release }}
+        prod_release: ${{ inputs.build_type == 'prod' }}
 
     - name: Build apk (dev)
       if: ${{ inputs.build_type == 'dev' }}

--- a/.github/actions/build_ios/action.yml
+++ b/.github/actions/build_ios/action.yml
@@ -23,17 +23,24 @@ inputs:
     required: true
     description: "Store artifact"
   build_type:
-    required: false
-    default: "dev"
-    options:
-    - dev
-    - prod
+    required: true
+    description: >
+      Whether to build a development or production version of the app.
+      A 'development' build connects to the development backend for testing,
+      while a 'production' build connects to the production backend.
+      It is an error to specify a build type other than
+      'development' or 'production'.
 
 runs:
   using: "composite"
   steps:
-    - name: Install Apple certificate and provisioning profile
-      if: ${{ inputs.prod_release != 'true' }}
+    - name: Validate build_type
+      uses: ./.github/actions/verify_build_type
+      with:
+        build_type: ${{ inputs.build_type }}
+
+    - name: "[dev] Install Apple certificate and provisioning profile"
+      if: ${{ inputs.build_type == 'development' }}
       run: .github/scripts/setup_certs.sh
       env:
         APPLE_IOS_SIGNING_CERT: ${{ inputs.apple_ios_signing_cert }}
@@ -45,15 +52,15 @@ runs:
     - name: Setup Flutter environment
       uses: ./.github/actions/setup_flutter_environment
       with:
-        prod_release: ${{ inputs.build_type == 'prod' }}
+        build_type: ${{ inputs.build_type }}
 
-    - name: Build iOS (dev)
-      if: ${{ inputs.build_type != 'prod' }}
+    - name: "[dev] Build iOS app"
+      if: ${{ inputs.build_type == 'development' }}
       run: .github/scripts/build_ios_dev.sh ${{ inputs.version }} ${{ inputs.build_version }}
       shell: bash
 
-    - name: Build iOS (prod)
-      if: ${{ inputs.build_type == 'prod' }}
+    - name: "[prod] Build iOS app"
+      if: ${{ inputs.build_type == 'production' }}
       run: .github/scripts/build_ios_prod.sh ${{ inputs.version }} ${{ inputs.build_version }}
       shell: bash
 

--- a/.github/actions/setup_flutter_environment/action.yml
+++ b/.github/actions/setup_flutter_environment/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Setup Flutter environment
       uses: subosito/flutter-action@v2.11.0
       with:
-        flutter-version: 3.13.7
+        flutter-version: 3.16.0
         channel: "stable"
 
     - name: Download dependencies

--- a/.github/actions/setup_flutter_environment/action.yml
+++ b/.github/actions/setup_flutter_environment/action.yml
@@ -1,29 +1,35 @@
 name: Setup Flutter environment
 description: Setup the Flutter environment
 inputs:
-  prod_release:
-    required: false
-    default: 'false'
-    description: "Is prod release"
-
-env:
-  FLUTTER_VERSION: 3.13.7
+  build_type:
+    required: true
+    description: >
+      Whether to build a development or production version of the app.
+      A 'development' build connects to the development backend for testing,
+      while a 'production' build connects to the production backend.
+      It is an error to specify a build type other than
+      'development' or 'production'.
 
 runs:
   using: "composite"
   steps:
+    - name: Validate build_type
+      uses: ./.github/actions/verify_build_type
+      with:
+        build_type: ${{ inputs.build_type }}
+
     - name: Setup Flutter environment
       uses: subosito/flutter-action@v2.11.0
       with:
-        flutter-version: ${{ env.FLUTTER_VERSION }}
+        flutter-version: 3.13.7
         channel: "stable"
 
     - name: Download dependencies
       run: flutter pub get
       shell: bash
 
-    - name: Replace target URI in Production
-      if: ${{ inputs.prod_release == 'true' }}
+    - name: "[prod] Change target backend to production"
+      if: ${{ inputs.build_type == 'production' }}
       run: sed -i'' -e 's/.env.develop/.env.production/' lib/env/env.dart
       shell: bash
 

--- a/.github/actions/verify_build_type/action.yml
+++ b/.github/actions/verify_build_type/action.yml
@@ -20,4 +20,5 @@ runs:
           echo "Error: build_type must be 'development' or 'production'"
           exit 1
         fi
+        echo "Build type: ${{ inputs.build_type }}"
       shell: bash

--- a/.github/actions/verify_build_type/action.yml
+++ b/.github/actions/verify_build_type/action.yml
@@ -1,0 +1,23 @@
+name: Verify build type
+description: Verify that the build type is either 'development' or 'production'
+
+inputs:
+  build_type:
+    required: true
+    description: >
+      Whether to build a development or production version of the app.
+      A 'development' build connects to the development backend for testing,
+      while a 'production' build connects to the production backend.
+      It is an error to specify a build type other than
+      'development' or 'production'.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate build_type
+      run: |
+        if [[ "${{ inputs.build_type }}" != "development" && "${{ inputs.build_type }}" != "production" ]]; then
+          echo "Error: build_type must be 'development' or 'production'"
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.0
+
+      - name: Validate build_type
+        uses: ./.github/actions/verify_build_type
+        with:
+          build_type: ${{ inputs.build_type }}
+
       - name: Determine build version
         id: build_version
         run: |
@@ -53,11 +61,6 @@ jobs:
     runs-on: macos-latest
     needs: [version]
     steps:
-      - name: Validate build_type
-        uses: ./.github/actions/verify_build_type
-        with:
-          build_type: ${{ inputs.build_type }}
-
       - name: Checkout code
         uses: actions/checkout@v4.1.0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,13 @@ on:
         required: true
       build_type:
         type: string
-        required: false
-        default: "dev"
+        required: true
+        description: >
+          Whether to build a development or production version of the app.
+          A 'development' build connects to the development backend for testing,
+          while a 'production' build connects to the production backend.
+          It is an error to specify a build type other than
+          'development' or 'production'.
 
 jobs:
   version:
@@ -48,11 +53,16 @@ jobs:
     runs-on: macos-latest
     needs: [version]
     steps:
+      - name: Validate build_type
+        uses: ./.github/actions/verify_build_type
+        with:
+          build_type: ${{ inputs.build_type }}
+
       - name: Checkout code
         uses: actions/checkout@v4.1.0
 
-      - name: Build iOS app (dev)
-        if: ${{ inputs.build_type != 'prod' }}
+      - name: "[dev] Build iOS app"
+        if: ${{ inputs.build_type == 'development' }}
         uses: ./.github/actions/build_ios
         with:
           version: ${{ needs.version.outputs.version }}
@@ -64,8 +74,8 @@ jobs:
           store_artifacts: ${{ inputs.store_artifacts }}
           build_type: ${{ inputs.build_type }}
 
-      - name: Build iOS app (prod)
-        if: ${{ inputs.build_type == 'prod' }}
+      - name: "[prod] Build iOS app"
+        if: ${{ inputs.build_type == 'production' }}
         uses: ./.github/actions/build_ios
         with:
           version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       store_artifacts: true
-      build_type: "dev"
+      build_type: development
       tag_name: ${{ github.head_ref }}
     secrets: inherit
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       store_artifacts: true
-      build_type: "prod"
+      build_type: production
       tag_name: ${{ github.event.release.tag_name }}
     secrets: inherit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Flutter environment
         uses: ./.github/actions/setup_flutter_environment
+        with:
+          build_type: development
 
       - name: Check formatting
         run: dart format --set-exit-if-changed lib/


### PR DESCRIPTION
This PR fixes the release pipeline bug that caused building a development version for release (in the first commit), and increases code robustness to prevent the same bug from appearing again (in the second commit).

The error was caused by a bug in actions code, which passed an ill-defined input variable (whether to build a dev/prod app) to another action. The input variable expected by the second action was optional, defaulting to build a dev version if no input variable is present.

---

Build configurations across Android and iOS build pipelines were updated to enforce the specification of 'development' or 'production' as mandatory build types. Introduced a shared 'verify_build_type' action that validates this input. This change ensures that artifacts are built against the correct backend environments and clarifies the pipeline behavior by removing ambiguity in build type selection. Additionally, updated steps to reflect the new build type validation and adjusted environment setup actions to accommodate the enforcement of build types.

Finally, this PR fixes the following yml syntax/schema errors:
- `inputs.<id>.options` in an action
- `env` on the root level of an action