### PR TITLE
fix(ci): apple certs not installed on prod

### DIFF
--- a/.github/actions/build_ios/action.yml
+++ b/.github/actions/build_ios/action.yml
@@ -39,8 +39,7 @@ runs:
       with:
         build_type: ${{ inputs.build_type }}
 
-    - name: "[dev] Install Apple certificate and provisioning profile"
-      if: ${{ inputs.build_type == 'development' }}
+    - name: Install Apple certificate and provisioning profile
       run: .github/scripts/setup_certs.sh
       env:
         APPLE_IOS_SIGNING_CERT: ${{ inputs.apple_ios_signing_cert }}


### PR DESCRIPTION
this PR will change the build_ios action to always install certificates and provisioning profiles, instead of only doing so for development builds.