### PR TITLE
feat(purchase): add guardrails for failed purchases

### DIFF
--- a/lib/core/strings.dart
+++ b/lib/core/strings.dart
@@ -193,7 +193,7 @@ abstract final class Strings {
   static const purchaseSuccess = 'Success';
   static const purchaseRejectedOrCanceled = 'Payment rejected or canceled';
   static const purchaseRejectedOrCanceledMessage =
-      'The payment was rejected or cancelled. No tickets have been added to your account';
+      'Seems like the payment was rejected or cancelled. Please double check that the purchase was cancelled on MobilePay.';
   static const purchaseError = "Uh oh, we couldn't complete that purchase";
   static const purchaseTimeout = 'Purchase timed out';
   static const purchaseTimeoutMessage =

--- a/lib/features/ticket/presentation/cubit/tickets_cubit.dart
+++ b/lib/features/ticket/presentation/cubit/tickets_cubit.dart
@@ -17,8 +17,17 @@ class TicketsCubit extends Cubit<TicketsState> {
   }) : super(const TicketsLoading());
 
   Future<void> getTickets() async {
-    emit(const TicketsLoading());
-    return refreshTickets();
+    return _refreshTickets();
+  }
+
+  Future<void> refreshTickets() async {
+    switch (state) {
+      case final TicketsLoaded loaded:
+        emit(TicketsRefreshing(tickets: loaded.tickets));
+        return _refreshTickets();
+      default:
+        return;
+    }
   }
 
   Future<void> useTicket(int productId, int menuItemId) async {
@@ -38,10 +47,10 @@ class TicketsCubit extends Cubit<TicketsState> {
         .map(emit)
         .run();
 
-    return refreshTickets();
+    return _refreshTickets();
   }
 
-  Future<void> refreshTickets() => loadTickets()
+  Future<void> _refreshTickets() => loadTickets()
       .match(
         (failure) => TicketsLoadError(message: failure.reason),
         (tickets) => TicketsLoaded(tickets: tickets),

--- a/lib/features/ticket/presentation/cubit/tickets_state.dart
+++ b/lib/features/ticket/presentation/cubit/tickets_state.dart
@@ -51,5 +51,12 @@ class TicketsUseError extends TicketsAction {
   const TicketsUseError({required this.message, required super.tickets});
 
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [message, tickets];
+}
+
+class TicketsRefreshing extends TicketsLoaded {
+  const TicketsRefreshing({required super.tickets});
+
+  @override
+  List<Object?> get props => [tickets];
 }

--- a/lib/features/ticket/presentation/pages/tickets_page.dart
+++ b/lib/features/ticket/presentation/pages/tickets_page.dart
@@ -2,6 +2,7 @@ import 'package:coffeecard/core/strings.dart';
 import 'package:coffeecard/core/widgets/components/barista_perks_section.dart';
 import 'package:coffeecard/core/widgets/components/scaffold.dart';
 import 'package:coffeecard/features/product/purchasable_products.dart';
+import 'package:coffeecard/features/ticket/presentation/cubit/tickets_cubit.dart';
 import 'package:coffeecard/features/ticket/presentation/widgets/shop_section.dart';
 import 'package:coffeecard/features/ticket/presentation/widgets/tickets_section.dart';
 import 'package:coffeecard/features/user/presentation/cubit/user_cubit.dart';
@@ -28,22 +29,26 @@ class TicketsPage extends StatelessWidget {
     return UpgradeAlert(
       child: AppScaffold.withTitle(
         title: Strings.ticketsPageTitle,
-        body: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(
-              child: ListView(
-                controller: scrollController,
-                shrinkWrap: true,
-                padding: const EdgeInsets.all(16.0),
-                children: [
-                  const TicketSection(),
-                  if (perksAvailable) BaristaPerksSection(userRole: user.role),
-                  const ShopSection(),
-                ],
+        body: RefreshIndicator(
+          onRefresh: context.read<TicketsCubit>().getTickets,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: ListView(
+                  controller: scrollController,
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.all(16.0),
+                  children: [
+                    const TicketSection(),
+                    if (perksAvailable)
+                      BaristaPerksSection(userRole: user.role),
+                    const ShopSection(),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/voucher/presentation/pages/redeem_voucher_page.dart
+++ b/lib/features/voucher/presentation/pages/redeem_voucher_page.dart
@@ -30,6 +30,9 @@ class RedeemVoucherPage extends StatelessWidget {
               return;
             }
             final _ = LoadingOverlay.hide(context);
+            // Refresh tickets, so the user sees the redeemed ticket(s)
+            // (we also refresh tickets in case of failure as a fail-safe)
+            context.read<TicketsCubit>().refreshTickets();
             if (state is VoucherSuccess) return _onSuccess(context, state);
             if (state is VoucherError) return _onError(context, state);
           },
@@ -40,9 +43,6 @@ class RedeemVoucherPage extends StatelessWidget {
   }
 
   void _onSuccess(BuildContext context, VoucherSuccess state) {
-    // Refresh tickets, so the user sees the redeemed ticket(s)
-    context.read<TicketsCubit>().refreshTickets();
-
     appDialog(
       context: context,
       title: Strings.voucherRedeemed,


### PR DESCRIPTION
1. always refresh user's tickets after purchase attempt
2. show a more open-ended error message if the purchase was cancelled/rejected to urge double-checking on user's end
3. enable pull to refresh on the Tickets page