### PR TITLE
fix(dialog): background color of dialogs

### DIFF
--- a/lib/core/widgets/components/dialog.dart
+++ b/lib/core/widgets/components/dialog.dart
@@ -10,7 +10,7 @@ Future<void> appDialog({
   required bool dismissible,
   bool transparentBarrier = false,
 }) async {
-  return showAdaptiveDialog(
+  return showDialog(
     context: context,
     barrierDismissible: dismissible,
     barrierColor: transparentBarrier ? Colors.transparent : AppColors.scrim,


### PR DESCRIPTION
On iOS the background color of dialogs are ignored when calling `showAdaptiveDialog`. Instead, calling `showDialog` creates a Material dialog which enforces the background/"barrier" color.