### PR TITLE
fix(purchase): hide perks products in "buy single drink" page

### DIFF
--- a/lib/features/product/presentation/cubit/product_state.dart
+++ b/lib/features/product/presentation/cubit/product_state.dart
@@ -17,7 +17,7 @@ class ProductsLoaded extends ProductState {
   ProductsLoaded(Iterable<Product> products)
       : products = (
           clipCards: products.where((p) => p.amount > 1),
-          singleDrinks: products.where((p) => p.amount == 1),
+          singleDrinks: products.where((p) => p.amount == 1 && !p.isPerk),
           perks: products.where((p) => p.isPerk),
         );
 


### PR DESCRIPTION
Attempting to claim perks in the "Buy single drink" page currently causes an error. Since these perks should only be shown on the home page anyways, they have been removed from the "Buy single drink" page.