### PR TITLE
fix(build): increase Gradle JVM memory allocation to 4g

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
after bumping Flutter version, it seems like it requires more memory to build the Android version of the app.